### PR TITLE
Project targets restructured to better align with Dev platforms

### DIFF
--- a/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
@@ -367,6 +367,14 @@
             "type": "computed",
             "value": "(target-platform == \"Base\")"
         },
+        "FirstLine": {
+            "type": "computed",
+            "value": "(IsAndroid || IsiOS || IsmacOS)"
+        },
+        "MorePlatforms": {
+            "type": "computed",
+            "value": "(IsWindows || IsTizen || IsBase)"
+        },
         "Unpackaged": {
             "type": "computed",
             "value": "(windows-unpackaged)"

--- a/src/MauiTemplatesCLI/MauiAppX/MainPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/MainPage.xaml
@@ -48,6 +48,7 @@
 <!--#else-->
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:MauiApp._1"
              x:Class="MauiApp._1.MainPage">
 
     <ScrollView>

--- a/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
@@ -8,30 +8,85 @@
         <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst;MAUI_TFM-windows10.0.19041.0</TargetFrameworks>
+        <!--#if (Net8)-->
+        <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks> -->
+        <!--#else-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks>
+        <!--#endif-->
+        <TargetFrameworks>$(TargetFrameworks);MAUI_TFM</TargetFrameworks>
         <!--#elif (IsAndroid && IsiOS && IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-android;MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
-        <!--#elif (IsAndroid && IsiOS)-->
-        <TargetFrameworks>MAUI_TFM-android;MAUI_TFM-ios</TargetFrameworks>
-        <!--#elif (IsiOS && IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
-        <!--#elif (IsAndroid && IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-android;MAUI_TFM-maccatalyst</TargetFrameworks>
-        <!--#elif (IsAndroid)-->
         <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#elif (IsAndroid && IsiOS)-->
+        <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-ios</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-ios</TargetFrameworks>
+        <!--#elif (IsiOS && IsmacOS)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#elif (IsAndroid && IsmacOS)-->
+        <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#elif (IsAndroid)-->
+        <!--#if (MorePlatforms)-->
+        <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework>MAUI_TFM-android</TargetFramework>
+        <!--#endif-->
         <!--#elif (IsiOS)-->
-        <TargetFrameworks>MAUI_TFM-ios</TargetFrameworks>
+        <!--#if (MorePlatforms)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-ios</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-ios</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-ios</TargetFramework>
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-ios</TargetFramework>
+        <!--#endif-->
         <!--#elif (IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#if (MorePlatforms)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-maccatalyst</TargetFramework>
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-maccatalyst</TargetFramework>
+        <!--#endif-->
         <!--#endif-->
         <!--#if (IsWindows)-->
         <!-- Targets possible from Windows OS -->
+        <!--#if (FirstLine)-->
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-windows10.0.19041.0</TargetFrameworks>
+        <!--#elif (IsTizen || IsBase)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-windows10.0.19041.0</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-windows10.0.19041.0</TargetFramework>
         <!--#endif-->
-        <!--#if (AllPlatforms || IsTizen)-->
-        <TargetFrameworks>$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks>
         <!--#endif-->
-        <!--#if (AllPlatforms || IsBase)-->
+        <!--#if (IsTizen)-->
+        <!--#if (Net8)-->
+        <!--#if (FirstLine || IsWindows)-->
+        <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks> -->
+        <!--#elif (IsBase)-->
+        <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFrameworks> -->
+        <!--#else-->
+        <!-- <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFramework> -->
+        <!--#endif-->
+        <!--#else-->
+        <!--#if (FirstLine || IsWindows)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks>
+        <!--#elif (IsBase)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFramework>
+        <!--#endif-->
+        <!--#endif-->
+        <!--#endif-->
+        <!--#if (IsBase)-->
+        <!--#if (FirstLine || IsWindows || IsTizen)-->
         <TargetFrameworks>$(TargetFrameworks);MAUI_TFM</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework>MAUI_TFM</TargetFramework>
+        <!--#endif-->
         <!--#endif-->
         <OutputType Condition="'$(TargetFramework)' != 'MAUI_TFM'">Exe</OutputType>
 

--- a/src/MauiTemplatesCLI/MauiClassLib/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiClassLib/.template.config/ide.host.json
@@ -21,7 +21,15 @@
         {
             "id": "use-maui-core",
             "name": {
-                "text": "Use .NET MAUI _Core"
+                "text": "Use .NET MAUI _Core (includes MAUI Essentials)"
+            },
+            "isVisible": true,
+            "defaultValue": "false"
+        },
+        {
+            "id": "use-maui-essentials",
+            "name": {
+                "text": "Use .NET MAUI _Essentials"
             },
             "isVisible": true,
             "defaultValue": "false"

--- a/src/MauiTemplatesCLI/MauiClassLib/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiClassLib/.template.config/template.json
@@ -56,15 +56,22 @@
             "type": "parameter",
             "datatype": "bool",
             "defaultValue": "false",
-            "description": "Option to use Razor SDK.",
-            "displayName": "Option to use Razor SDK"
+            "description": "Option to use .NET Razor SDK.",
+            "displayName": "Option to use .NET Razor SDK"
         },
         "use-maui-core": {
             "type": "parameter",
             "datatype": "bool",
             "defaultValue": "false",
-            "description": "Option to use .NET MAUI Core.",
-            "displayName": "Option to use .NET MAUI _Core"
+            "description": "Option to use .NET MAUI Core (includes MAUI Essentials).",
+            "displayName": "Option to use .NET MAUI _Core (includes MAUI Essentials)"
+        },
+        "use-maui-essentials": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "Option to use .NET MAUI Essentials.",
+            "displayName": "Option to use .NET MAUI _Essentials"
         },
         "target-platform": {
             "type": "parameter",
@@ -164,6 +171,14 @@
             "type": "computed",
             "value": "(use-maui-core)"
         },
+        "UseMauiEssentials": {
+            "type": "computed",
+            "value": "(use-maui-essentials)"
+        },
+        "Net8": {
+            "type": "computed",
+            "value": "(frameworkLower == \"net8.0\")"
+        },
         "Net7OrLater": {
             "type": "computed",
             "value": "(frameworkLower == \"net7.0\" || frameworkLower == \"net8.0\")"
@@ -195,6 +210,14 @@
         "IsBase": {
             "type": "computed",
             "value": "(target-platform == \"Base\")"
+        },
+        "FirstLine": {
+            "type": "computed",
+            "value": "(IsAndroid || IsiOS || IsmacOS)"
+        },
+        "MorePlatforms": {
+            "type": "computed",
+            "value": "(IsWindows || IsTizen || IsBase)"
         },
         "AddToolkitPackage": {
             "type": "computed",

--- a/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
+++ b/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
@@ -8,35 +8,92 @@
         <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst;MAUI_TFM-windows10.0.19041.0</TargetFrameworks>
+        <!--#if (Net8)-->
+        <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks> -->
+        <!--#else-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks>
+        <!--#endif-->
+        <TargetFrameworks>$(TargetFrameworks);MAUI_TFM</TargetFrameworks>
         <!--#elif (IsAndroid && IsiOS && IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-android;MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
-        <!--#elif (IsAndroid && IsiOS)-->
-        <TargetFrameworks>MAUI_TFM-android;MAUI_TFM-ios</TargetFrameworks>
-        <!--#elif (IsiOS && IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
-        <!--#elif (IsAndroid && IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-android;MAUI_TFM-maccatalyst</TargetFrameworks>
-        <!--#elif (IsAndroid)-->
         <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#elif (IsAndroid && IsiOS)-->
+        <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-ios</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-ios</TargetFrameworks>
+        <!--#elif (IsiOS && IsmacOS)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-ios;MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#elif (IsAndroid && IsmacOS)-->
+        <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#elif (IsAndroid)-->
+        <!--#if (MorePlatforms)-->
+        <TargetFrameworks>MAUI_TFM-android</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework>MAUI_TFM-android</TargetFramework>
+        <!--#endif-->
         <!--#elif (IsiOS)-->
-        <TargetFrameworks>MAUI_TFM-ios</TargetFrameworks>
+        <!--#if (MorePlatforms)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-ios</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-ios</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-ios</TargetFramework>
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-ios</TargetFramework>
+        <!--#endif-->
         <!--#elif (IsmacOS)-->
-        <TargetFrameworks>MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#if (MorePlatforms)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-maccatalyst</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('osx'))">MAUI_TFM-maccatalyst</TargetFramework>
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-maccatalyst</TargetFramework>
+        <!--#endif-->
         <!--#endif-->
         <!--#if (IsWindows)-->
         <!-- Targets possible from Windows OS -->
+        <!--#if (FirstLine)-->
         <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-windows10.0.19041.0</TargetFrameworks>
+        <!--#elif (IsTizen || IsBase)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-windows10.0.19041.0</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-windows10.0.19041.0</TargetFramework>
         <!--#endif-->
-        <!--#if (AllPlatforms || IsTizen)-->
-        <TargetFrameworks>$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks>
         <!--#endif-->
-        <!--#if (AllPlatforms || IsBase)-->
+        <!--#if (IsTizen)-->
+        <!--#if (Net8)-->
+        <!--#if (FirstLine || IsWindows)-->
+        <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks> -->
+        <!--#elif (IsBase)-->
+        <!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFrameworks> -->
+        <!--#else-->
+        <!-- <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFramework> -->
+        <!--#endif-->
+        <!--#else-->
+        <!--#if (FirstLine || IsWindows)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);MAUI_TFM-tizen</TargetFrameworks>
+        <!--#elif (IsBase)-->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('windows'))">MAUI_TFM-tizen</TargetFramework>
+        <!--#endif-->
+        <!--#endif-->
+        <!--#endif-->
+        <!--#if (IsBase)-->
+        <!--#if (FirstLine || IsWindows || IsTizen)-->
         <TargetFrameworks>$(TargetFrameworks);MAUI_TFM</TargetFrameworks>
+        <!--#else-->
+        <TargetFramework>MAUI_TFM</TargetFramework>
+        <!--#endif-->
         <!--#endif-->
 
         <!-- .NET MAUI -->
         <!--#if (UseMauiCore)-->
         <UseMauiCore>true</UseMauiCore>
+        <!--#elif (UseMauiEssentials)-->
+        <UseMauiEssentials>true</UseMauiEssentials>
         <!--#else-->
         <UseMaui>true</UseMaui>
         <!--#endif-->

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.1.0-preview.1
+3.1.0-preview.2

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,5 +1,29 @@
-What's new in ver. 3.1.0-preview.1:
+What's new in ver. 3.1.0-preview.2:
 -----------------------------------
+1. .NET MAUI App and Library project framework targets were restructured to better align with the development/build platforms.
+
+This enables to make use of the template without any modification across OS such as Windows, macOS, and Linux.
+
+2. .NET MAUI Class Library can be created target .NET MAUI Essentials.
+
+Parameter name: --use-maui-essentials | -ume
+
+3. While targeting .NET 8 Preview, the Tizen platform target is commented out in the project file as a public preview of the Tizen workload is yet to be made available.
+
+This will be re-enabled once the workload is made available.
+
+Examples:
+
+With default values, below command creates a library project for .NET 7 with Target Platform set to All.
+
+dotnet new mauiclasslib -o MyLib -ume
+
+Below command creates a library project for .NET 8 with Target Platform set to Mobile (iOS and Android) and .NET 8 (Base framework).
+
+dotnet new mauiclasslib -f net8.0 -o MyLib -ume -tp Mobile Base
+
+v3.1.0-preview.1:
+
 1. Similar to the All-in-One .NET MAUI App, the Class Library project template also takes target-platform as a parameter that takes a combination of the following values (with All being the default value).
 
 All      Targets all possible .NET MAUI-supported platforms.
@@ -17,9 +41,11 @@ Apple    Targets iOS and macOS platforms.
 
 Parameter name: --use-razor-sdk | -usr
 
-3.  .NET MAUI Class Library can be created target .NET MAUI Core.
+3. .NET MAUI Class Library can be created target .NET MAUI Core.
 
 Parameter name: --use-maui-core | -umc
+
+Note: .NET MAUI Essentials is a transitive dependency to .NET MAUI Core.
 
 Examples:
 


### PR DESCRIPTION
* .NET MAUI App and Library project framework targets were restructured to better align with the development/build platforms.

This enables to make use of the template without any modification across OS such as Windows, macOS, and Linux.

* .NET MAUI Class Library can be created to target .NET MAUI Essentials.

Parameter name: `--use-maui-essentials` | `-ume`

* While targeting .NET 8 Preview, the Tizen platform target is commented out in the project file as a public preview of the Tizen workload is yet to be made available.

This will be re-enabled once the workload is made available.

**Examples:**

With default values, the below command creates a library project for .NET 7 with the Target Platform set to All.

```shell
dotnet new mauiclasslib -o MyLib -ume
```

And the below command creates a library project for .NET 8 with the Target Platform set to Mobile (iOS and Android) and .NET 8 (Base framework).

```shell
dotnet new mauiclasslib -o MyLib -f net8.0 -ume -tp Mobile Base
```