### PR TITLE
Razor templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,20 @@ This comes with with the following templates:
 
 Name | Template Name | Type
 :---: | :---: | :---:
-.NET MAUI App | mauiapp | Project
-.NET MAUI Class Library | mauiclasslib | Project
-Shared Class Library | sharedclasslib | Project
+[All-in-One .NET MAUI App](#all-in-one-net-maui-app-project-template) | mauiapp | Project
+[.NET MAUI Class Library](#net-maui-class-library-template) | mauiclasslib | Project
+[Shared Class Library](#shared-class-library-template) | sharedclasslib | Project
 ContentPage (XAML) | maui-page | Item
 ContentPage (C#) | maui-page-cs | Item
+ContentPage (Razor) | maui-page-razor | Item
 ContentView (XAML) | maui-view | Item
 ContentView (C#) | maui-view-cs | Item
+ContentView (Razor) | maui-view-razor | Item
 ResourceDictionary | maui-resdict | Item
 ShellPage (XAML) | maui-shell | Item
 ShellPage (C#) | maui-shell-cs | Item
-Partial Class (C#) | class-cs | Item
+ShellPage (Razor) | maui-shell-razor | Item
+[Partial Class (C#)](#partial-class-item-template) | class-cs | Item
 
 ![All-in-One .NET MAUI App Project Template](images/dotnetmaui-all-in-one-project-template-pinned.png)
 
@@ -254,6 +257,7 @@ Can take any one of the following values, with default value set to `Plain`:
 |Tab|App configured to work in a Tabbed fashion using TabbedPage.|
 |Shell|App configured to work with Routes using Shell page.|
 |Hybrid|App configured to work in a Hybrid fashion using BlazorWebView.|
+|Razor|App configured to work with Razor syntax.|
 
 * `-tp` | `--target-platform`
 
@@ -262,7 +266,7 @@ Can take a combination of the following values, with default value set to `All`:
 |Parameter Value|Description|
 |:---:|:---|
 |All|Targets all possible .NET MAUI supported platforms.|
-|Base|Base framework (.NET 6/7/8)|
+|Base|Base framework (.NET 6/7/8) based on the framework opted.|
 |Android|Targets Android platform.|
 |iOS|Targets iOS platform.|
 |macOS|Targets macOS platform via Mac Catalyst.|
@@ -283,6 +287,17 @@ dotnet new mauiapp --design-pattern Hybrid --target-platform Mobile
   ```shell
 dotnet new mauiapp -dp Shell -tp Android iOS Windows
 ```
+
+#### .NET MAUI Class Library Template:
+
+Similar to All-in-One .NET MAUI App, the Class Library project template also takes `target-platform` as a parameter that takes a combination from the same set of values (with `All` being the default value).
+
+* Can be created targeting .NET Razor SDK
+  - Parameter name: `--use-razor-sdk` | `-usr`
+* Can be created targeting .NET MAUI Core
+  - Parameter name: `--use-maui-core` | `-umc`
+* Can be created targeting .NET MAUI Essentials
+  - Parameter name: `--use-maui-essentials` | `-ume`
 
 #### Shared Class Library Template:
 
@@ -321,6 +336,28 @@ dotnet new mauiclasslib --help
 dotnet new sharedclasslib --help
 ```
 
+#### Partial Class Item Template:
+
+This item template (short name: `class-cs`) allows to create a C# class from CLI with support for multiple options.
+
+|Parameter Name|Type|Default Value|Remarks|
+|:--:|:---:|:---:|:---|
+access-modifier|choice|public|Specifies the accessibility of the class type.|
+base|text|object|Specifies the base type for the class.|
+abstract|bool|false|Option to create the type as abstract.|
+partial|bool|true|Option to create the type as partial.|
+sealed|bool|false|Option to create the type as sealed.|
+static|bool|false|Option to create the type as static.|
+
+Access Modifier parameter (`--access-modifier` | `-am`):
+
+Supported values are:
+
+* public (default value, if not provided)
+* internal
+* protected
+* private
+
 #### Usage:
 
 After installation, use the below command(s) to create new artifacts using the template (both provide the same output):
@@ -330,7 +367,13 @@ With parameter names abbreviated:
 
 .NET MAUI App:
 ```shell
+dotnet new mauiapp -n MyApp -dp Shell
+```
+```shell
 dotnet new mauiapp -n MyApp -dp Hybrid
+```
+```shell
+dotnet new mauiapp -n MyApp -dp Razor
 ```
 Option to include NuGet packages:
 ```shell
@@ -370,6 +413,9 @@ dotnet new maui-page -n LoginPage -na MyApp.Views
 ```shell
 dotnet new maui-page-cs -n HomePage -na MyApp.Views
 ```
+```shell
+dotnet new maui-page-razor -n HomePage
+```
 
 Views:
 ```shell
@@ -378,6 +424,9 @@ dotnet new maui-view -n CardView -na MyApp.Views
 ```shell
 dotnet new maui-view-cs -n OrderView -na MyApp.Views
 ```
+```shell
+dotnet new maui-view-razor -n OrderView
+```
 
 Shell:
 ```shell
@@ -385,6 +434,9 @@ dotnet new maui-shell -n AppShell -na MyApp
 ```
 ```shell
 dotnet new maui-shell-cs -n AppShell -na MyApp
+```
+```shell
+dotnet new maui-shell-razor -n AppShell
 ```
 
 Resource Dictionary:
@@ -397,14 +449,20 @@ Partial Class:
 dotnet new class-cs -n BaseViewModel
 ```
 ```shell
-dotnet new class-cs -n OrderDataStore -b IDataStore -p false
+dotnet new class-cs -n OrderDataStore -b IDataStore -p false -am internal
 ```
 
 With parameter names expanded:
 
 .NET MAUI App:
 ```shell
+dotnet new mauiapp --name MyApp --design-pattern Shell
+```
+```shell
 dotnet new mauiapp --name MyApp --design-pattern Hybrid
+```
+```shell
+dotnet new mauiapp --name MyApp --design-pattern Razor
 ```
 Option to include NuGet packages:
 ```shell
@@ -440,6 +498,9 @@ dotnet new maui-page --name LoginPage --namespace MyApp.Views
 ```shell
 dotnet new maui-page-cs --name HomePage --namespace MyApp.Views
 ```
+```shell
+dotnet new maui-page-razor --name HomePage
+```
 
 Views:
 ```shell
@@ -448,6 +509,9 @@ dotnet new maui-view --name CardView --namespace MyApp.Views
 ```shell
 dotnet new maui-view-cs --name OrderView --namespace MyApp.Views
 ```
+```shell
+dotnet new maui-view-razor --name OrderView
+```
 
 Shell:
 ```shell
@@ -455,6 +519,9 @@ dotnet new maui-shell --name AppShell --namespace MyApp
 ```
 ```shell
 dotnet new maui-shell-cs --name AppShell --namespace MyApp
+```
+```shell
+dotnet new maui-shell-razor --name AppShell
 ```
 
 Resource Dictionary:
@@ -467,7 +534,7 @@ Partial Class:
 dotnet new class-cs --name BaseViewModel
 ```
 ```shell
-dotnet new class-cs --name OrderDataStore --base IDataStore --partial false
+dotnet new class-cs --name OrderDataStore --base IDataStore --partial false --access-modifier internal
 ```
 <!--
 ### For VS2019 users:

--- a/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
@@ -43,14 +43,30 @@
                     ]
                 },
                 {
-                    "condition": "(!Hybrid)",
+                    "condition": "(Xaml)",
                     "exclude": [
                         "**/Data/**",
                         "**/Pages/**",
                         "**/Shared/**",
                         "**/wwwroot/**",
-                        "**/*.razor"
+                        "**/*.razor",
+                        "**/*.razor.cs"
                     ]
+                },
+                {
+                    "condition": "(Razor)",
+                    "exclude": [
+                        "Main.razor",
+                        "**/Data/**",
+                        "**/Pages/**",
+                        "**/Shared/**",
+                        "**/wwwroot/**",
+                        "*.xaml",
+                        "*.xaml.cs"
+                    ],
+                    "rename": {
+                        "App.razor.cs": "App.cs"
+                    }
                 },
                 {
                     "condition": "(Shell)",
@@ -85,8 +101,15 @@
                     ]
                 },
                 {
+                    "condition": "(Hybrid)",
+                    "exclude": [
+                        "MainPage.razor"
+                    ]
+                },
+                {
                     "condition": "(Plain || Hybrid)",
                     "exclude": [
+                        "App.razor.cs",
                         "NewEventPage.xaml",
                         "NewEventPage.xaml.cs",
                         "DateTimePicker.xaml",
@@ -161,6 +184,10 @@
                 {
                     "choice": "Hybrid",
                     "description": "App configured to work in a Hybrid fashion using BlazorWebView."
+                },
+                {
+                    "choice": "Razor",
+                    "description": "App configured to work with Razor syntax."
                 }
             ]
         },
@@ -326,6 +353,14 @@
         "Hybrid": {
             "type": "computed",
             "value": "(design-pattern == \"Hybrid\" || designPatternLower == \"hybrid\")"
+        },
+        "Razor": {
+            "type": "computed",
+            "value": "(design-pattern == \"Razor\" || designPatternLower == \"razor\")"
+        },
+        "Xaml": {
+            "type": "computed",
+            "value": "(Plain || Hierarchical || Tabbed || Shell)"
         },
         "Net7": {
             "type": "computed",

--- a/src/MauiTemplatesCLI/MauiAppX/App.razor.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/App.razor.cs
@@ -1,0 +1,10 @@
+﻿namespace MauiApp._1
+{
+    public partial class App : BlazorBindingsApplication<AppShell>
+    {
+        public App(IServiceProvider services) : base(services)
+        {
+
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiAppX/AppShell.razor
+++ b/src/MauiTemplatesCLI/MauiAppX/AppShell.razor
@@ -1,0 +1,10 @@
+﻿<Shell>
+    @* Define Shell Flyout and Tab Items *@
+    <ShellContent Title="Home">
+        <MainPage />
+    </ShellContent>
+</Shell>
+
+@code {
+    
+}

--- a/src/MauiTemplatesCLI/MauiAppX/Imports.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Imports.cs
@@ -1,3 +1,7 @@
+#if Razor
+global using BlazorBindings.Maui;
+
+#endif
 #if AddToolkitPackage
 // .NET MAUI Toolkit
 global using CommunityToolkit.Maui;

--- a/src/MauiTemplatesCLI/MauiAppX/MainPage.razor
+++ b/src/MauiTemplatesCLI/MauiAppX/MainPage.razor
@@ -1,0 +1,35 @@
+﻿@page "/main"
+
+<ContentPage>
+    <ScrollView>
+        <VerticalStackLayout Spacing="25" Padding="new(30,0)" VerticalOptions="LayoutOptions.Center">
+
+            <Image Source="dotNetBotSource" HeightRequest="200" HorizontalOptions="LayoutOptions.Center" />
+
+            <Label Text="Hello, World!" FontSize="32" HorizontalOptions="LayoutOptions.Center" />
+
+            <Label Text="Welcome to .NET Multi-platform App UI" FontSize="18"
+                HorizontalOptions="LayoutOptions.Center" />
+
+            <Button Text="@ButtonText" HorizontalOptions="LayoutOptions.Center" OnClick="OnCounterClicked" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>
+
+@code {
+    ImageSource dotNetBotSource = ImageSource.FromFile("dotnet_bot.png");
+
+    int count = 0;
+
+    string ButtonText => count switch
+    {
+        0 => "Click me",
+        1 => $"Clicked 1 time",
+        _ => $"Clicked {count} times"
+    };
+
+    void OnCounterClicked()
+    {
+        count++;
+    }
+}

--- a/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
@@ -1,4 +1,4 @@
-<!--#if (Hybrid)-->
+<!--#if (Hybrid || Razor)-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 <!--#else-->
 <Project Sdk="Microsoft.NET.Sdk">
@@ -93,7 +93,7 @@
         <!-- .NET MAUI -->
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
-        <!--#if (Hybrid)-->
+        <!--#if (Hybrid || Razor)-->
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
         <!--#endif-->
 
@@ -149,9 +149,12 @@
         <None Remove="MauiApp.1.code-workspace" />
     </ItemGroup>
 
-    <!--#if (AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater)-->
+    <!--#if (AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater || Razor)-->
     <ItemGroup>
     <!--#endif-->
+        <!--#if (Razor)-->
+        <PackageReference Include="BlazorBindings.Maui" Version="1.0.1" />
+        <!--#endif-->
         <!--#if (AddFoldablePackage)-->
         <PackageReference Include="Microsoft.Maui.Controls.Foldable" Version="7.0.52" />
         <!--#endif-->
@@ -184,7 +187,7 @@
         <!--#if (AddMvvmToolkitPackage)-->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0"/>
         <!--#endif-->
-    <!--#if (AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater)-->
+    <!--#if (AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater || Razor)-->
     </ItemGroup>
     <!--#endif-->
 

--- a/src/MauiTemplatesCLI/MauiAppX/MauiProgram.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiProgram.cs
@@ -1,4 +1,7 @@
-﻿#if (AddToolkitPackage || AddMediaPackage)
+﻿#if Razor
+using BlazorBindings.Maui;
+#endif
+#if (AddToolkitPackage || AddMediaPackage)
 using CommunityToolkit.Maui;
 #endif
 #if Hybrid
@@ -10,7 +13,7 @@ using Microsoft.Extensions.Logging;
 #if AddFoldablePackage
 using Microsoft.Maui.Foldable;
 #endif
-#if (AddToolkitPackage || Hybrid || Net7OrLater || AddFoldablePackage)
+#if (AddToolkitPackage || Hybrid || Net7OrLater || AddFoldablePackage || Razor)
 
 #endif
 namespace MauiApp._1
@@ -21,6 +24,9 @@ namespace MauiApp._1
         {
             var builder = MauiApp.CreateBuilder();
             builder.UseMauiApp<App>()
+#if Razor
+                   .UseMauiBlazorBindings()
+#endif
 #if AddFoldablePackage
                    .UseFoldable()
 #endif

--- a/src/MauiTemplatesCLI/MauiAppX/_Imports.razor
+++ b/src/MauiTemplatesCLI/MauiAppX/_Imports.razor
@@ -1,8 +1,15 @@
-﻿@using System.Net.Http
+﻿@*#if (Razor)*@
+@using BlazorBindings.Maui
+@using BlazorBindings.Maui.Elements
+@using MC = Microsoft.Maui.Controls
+@*#endif*@
+@using System.Net.Http
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using MauiApp._1
+@*#if (Hybrid)*@
 @using MauiApp._1.Shared
+@*#endif*@

--- a/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
+++ b/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
@@ -94,6 +94,9 @@
         <UseMauiCore>true</UseMauiCore>
         <!--#elif (UseMauiEssentials)-->
         <UseMauiEssentials>true</UseMauiEssentials>
+        <!--#if (AllPlatforms || IsWindows)-->
+        <EnableMsixTooling>true</EnableMsixTooling>
+        <!--#endif-->
         <!--#else-->
         <UseMaui>true</UseMaui>
         <!--#endif-->

--- a/src/MauiTemplatesCLI/MauiPageRazor/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiPageRazor/.template.config/dotnetcli.host.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host"
+}

--- a/src/MauiTemplatesCLI/MauiPageRazor/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiPageRazor/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiPageRazor/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiPageRazor/.template.config/template.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "MauiPage1",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Windows",
+        "Razor"
+    ],
+    "identity": "VijayAnand.MauiPageRazor",
+    "groupIdentity": "VijayAnand.MauiTemplates.Page.Razor",
+    "description": "An item template for .NET MAUI ContentPage in Razor",
+    "name": ".NET MAUI ContentPage (Razor)",
+    "shortName": "maui-page-razor",
+    "sourceName": "MauiPage.1",
+    "primaryOutputs": [
+        {
+            "path": "MauiPage.1.razor"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    }
+}

--- a/src/MauiTemplatesCLI/MauiPageRazor/MauiPage.1.razor
+++ b/src/MauiTemplatesCLI/MauiPageRazor/MauiPage.1.razor
@@ -1,0 +1,9 @@
+﻿@page "/<page_route_here>"
+
+<ContentPage>
+    <Label Text="Hello .NET MAUI!!!" HorizontalOptions="LayoutOptions.Center" VerticalOptions="LayoutOptions.Center" />
+</ContentPage>
+
+@code {
+
+}

--- a/src/MauiTemplatesCLI/MauiShellRazor/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiShellRazor/.template.config/dotnetcli.host.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host"
+}

--- a/src/MauiTemplatesCLI/MauiShellRazor/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiShellRazor/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiShellRazor/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiShellRazor/.template.config/template.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "AppShell",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Mac Catalyst",
+        "WinUI",
+        "Windows",
+        "Shell"
+    ],
+    "identity": "VijayAnand.MauiShellRazor",
+    "groupIdentity": "VijayAnand.MauiTemplates.Shell.Razor",
+    "description": "An item template for .NET MAUI ShellPage in Razor",
+    "name": ".NET MAUI ShellPage (Razor)",
+    "shortName": "maui-shell-razor",
+    "sourceName": "MauiShell.1",
+    "primaryOutputs": [
+        {
+            "path": "MauiShell.1.razor"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    }
+}

--- a/src/MauiTemplatesCLI/MauiShellRazor/MauiShell.1.razor
+++ b/src/MauiTemplatesCLI/MauiShellRazor/MauiShell.1.razor
@@ -1,0 +1,10 @@
+﻿<Shell>
+    @* Define Shell Flyout and Tab Items *@
+    @* <ShellContent Title="">
+        <MyPage />
+    </ShellContent> *@
+</Shell>
+
+@code {
+
+}

--- a/src/MauiTemplatesCLI/MauiViewRazor/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiViewRazor/.template.config/dotnetcli.host.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host"
+}

--- a/src/MauiTemplatesCLI/MauiViewRazor/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiViewRazor/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiViewRazor/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiViewRazor/.template.config/template.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "MauiView1",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Windows",
+        "Razor"
+    ],
+    "identity": "VijayAnand.MauiViewRazor",
+    "groupIdentity": "VijayAnand.MauiTemplates.View.Razor",
+    "description": "An item template for .NET MAUI ContentView in Razor",
+    "name": ".NET MAUI ContentView (Razor)",
+    "shortName": "maui-view-razor",
+    "sourceName": "MauiView.1",
+    "primaryOutputs": [
+        {
+            "path": "MauiView.1.razor"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    }
+}

--- a/src/MauiTemplatesCLI/MauiViewRazor/MauiView.1.razor
+++ b/src/MauiTemplatesCLI/MauiViewRazor/MauiView.1.razor
@@ -1,0 +1,7 @@
+﻿<ContentView>
+    <Label Text="Hello .NET MAUI!!!" HorizontalOptions="LayoutOptions.Center" VerticalOptions="LayoutOptions.Center" />
+</ContentView>
+
+@code {
+
+}

--- a/src/MauiTemplatesCLI/MyClass/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MyClass/.template.config/template.json
@@ -27,6 +27,30 @@
             "replaces": "MyApp.Namespace",
             "defaultValue": "MyApp.Namespace"
         },
+        "access-modifier": {
+            "type": "parameter",
+            "datatype": "choice",
+            "defaultValue": "public",
+            "description": "Option to set the class access modifier.",
+            "choices": [
+                {
+                    "choice": "public",
+                    "description": "Class with public accessibility."
+                },
+                {
+                    "choice": "internal",
+                    "description": "Class with internal accessibility."
+                },
+                {
+                    "choice": "protected",
+                    "description": "Class with protected accessibility."
+                },
+                {
+                    "choice": "private",
+                    "description": "Class with private accessibility."
+                }
+            ]
+        },
         "base": {
             "type": "parameter",
             "description": "Base type for the class.",
@@ -60,6 +84,22 @@
             "defaultValue": "false",
             "description": "Option to create the class as static.",
             "displayName": "Option to create the class as static"
+        },
+        "IsPublic": {
+            "type": "computed",
+            "value": "(access-modifier == \"public\")"
+        },
+        "IsInternal": {
+            "type": "computed",
+            "value": "(access-modifier == \"internal\")"
+        },
+        "IsProtected": {
+            "type": "computed",
+            "value": "(access-modifier == \"protected\")"
+        },
+        "IsPrivate": {
+            "type": "computed",
+            "value": "(access-modifier == \"private\")"
         },
         "IsAbstract": {
             "type": "computed",

--- a/src/MauiTemplatesCLI/MyClass/MyClass.1.cs
+++ b/src/MauiTemplatesCLI/MyClass/MyClass.1.cs
@@ -1,5 +1,72 @@
 ﻿namespace MyApp.Namespace
 {
+#if IsInternal
+#if IsPartial
+#if IsAbstract
+    internal abstract partial class MyClass__1 : object
+#elif IsSealed
+    internal sealed partial class MyClass__1 : object
+#elif IsStatic
+    internal static partial class MyClass__1 : object
+#else
+    internal partial class MyClass__1 : object
+#endif
+#else
+#if IsAbstract
+    internal abstract class MyClass__1 : object
+#elif IsSealed
+    internal sealed class MyClass__1 : object
+#elif IsStatic
+    internal static class MyClass__1 : object
+#else
+    internal class MyClass__1 : object
+#endif
+#endif
+#elif IsProtected
+#if IsPartial
+#if IsAbstract
+    protected abstract partial class MyClass__1 : object
+#elif IsSealed
+    protected sealed partial class MyClass__1 : object
+#elif IsStatic
+    protected static partial class MyClass__1 : object
+#else
+    protected partial class MyClass__1 : object
+#endif
+#else
+#if IsAbstract
+    protected abstract class MyClass__1 : object
+#elif IsSealed
+    protected sealed class MyClass__1 : object
+#elif IsStatic
+    protected static class MyClass__1 : object
+#else
+    protected class MyClass__1 : object
+#endif
+#endif
+#elif IsPrivate
+#if IsPartial
+#if IsAbstract
+    private abstract partial class MyClass__1 : object
+#elif IsSealed
+    private sealed partial class MyClass__1 : object
+#elif IsStatic
+    private static partial class MyClass__1 : object
+#else
+    private partial class MyClass__1 : object
+#endif
+#else
+#if IsAbstract
+    private abstract class MyClass__1 : object
+#elif IsSealed
+    private sealed class MyClass__1 : object
+#elif IsStatic
+    private static class MyClass__1 : object
+#else
+    private class MyClass__1 : object
+#endif
+#endif
+#else
 #if IsPartial
 #if IsAbstract
     public abstract partial class MyClass__1 : object
@@ -19,6 +86,7 @@
     public static class MyClass__1 : object
 #else
     public class MyClass__1 : object
+#endif
 #endif
 #endif
     {

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.1.0-preview.2
+3.1.0-preview.3

--- a/src/MauiTemplatesCLI/VijayAnand.MauiTemplates.csproj
+++ b/src/MauiTemplatesCLI/VijayAnand.MauiTemplates.csproj
@@ -28,7 +28,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <Content Include="MauiPage\**\*;MauiPageCS\**\*;MauiView\**\*;MauiViewCS\**\*;MauiShell\**\*;MauiShellCS\**\*;MauiClassLib\**\*;MauiAppX\**\*;MauiResDict\**\*;SharedClassLib\**\*;MyClass\**\*"
+        <Content Include="MauiPage\**\*;MauiPageCS\**\*;MauiPageRazor\**\*;MauiView\**\*;MauiViewCS\**\*;MauiViewRazor\**\*;MauiShell\**\*;MauiShellCS\**\*;MauiShellRazor\**\*;MauiClassLib\**\*;MauiAppX\**\*;MauiResDict\**\*;SharedClassLib\**\*;MyClass\**\*"
                  Exclude="**\bin\**;**\obj\**"/>
         <Compile Remove="**\*"/>
         <None Include="overview.md" Pack="true" PackagePath="\" />

--- a/src/MauiTemplatesCLI/overview.md
+++ b/src/MauiTemplatesCLI/overview.md
@@ -1,8 +1,8 @@
 ### Project and Item Templates for developing .NET MAUI App that runs on iOS, Android, macOS, and Windows 
 
-* All-in-One project template for .NET MAUI App and is named as `mauiapp`
-* .NET MAUI Class Library project template and is named as `mauiclasslib`
-* Shared Class Library (Xamarin.Forms and .NET MAUI) project template and is named as `sharedclasslib`
+* [All-in-One .NET MAUI App](#all-in-one-net-maui-app-project-template) project template and is named as `mauiapp`
+* [.NET MAUI Class Library](#net-maui-class-library-project-template) project template and is named as `mauiclasslib`
+* [Shared Class Library](#shared-class-library-project-template) (Xamarin.Forms and .NET MAUI) project template and is named as `sharedclasslib`
 
 Item templates for the following:
 
@@ -10,12 +10,15 @@ Item templates for the following:
 |:---:|:---:|
 |ContentPage (XAML)|maui-page|
 |ContentPage (C#)|maui-page-cs|
+|ContentPage (Razor)|maui-page-razor|
 |ContentView (XAML)|maui-view|
 |ContentView (C#)|maui-view-cs|
+|ContentView (Razor)|maui-view-razor|
 |ResourceDictionary (XAML)|maui-resdict|
 |ShellPage (XAML)|maui-shell|
 |ShellPage (C#)|maui-shell-cs|
-|Partial Class (C#)|class-cs|
+|ShellPage (Razor)|maui-shell-razor|
+|[Partial Class (C#)](#partial-class-item-template)|class-cs|
 
 All of these templates currently target `.NET MAUI on .NET 6/7 GA and its Service Releases and .NET 8 Previews`.
 
@@ -173,6 +176,7 @@ Can take any one of the following values, with default value set to `Plain`:
 |Tab|App configured to work in a Tabbed fashion using TabbedPage.|
 |Shell|App configured to work with Routes using Shell page.|
 |Hybrid|App configured to work in a Hybrid fashion using BlazorWebView.|
+|Razor|App configured to work with Razor syntax.|
 
 * `-tp` | `--target-platform`
 
@@ -181,7 +185,7 @@ Can take a combination of the following values, with default value set to `All`:
 |Parameter Value|Description|
 |:---:|:---|
 |All|Targets all possible .NET MAUI supported platforms.|
-|Base|Targets base framework (.NET 6/7/8).|
+|Base|Targets base framework (.NET 6/7/8) based on the framework opted.|
 |Android|Targets Android platform.|
 |iOS|Targets iOS platform.|
 |macOS|Targets macOS platform via Mac Catalyst.|
@@ -200,6 +204,17 @@ dotnet new mauiapp --design-pattern Hybrid --target-platform Mobile
   ```shell
 dotnet new mauiapp -dp Shell -tp Android
 ```
+
+#### .NET MAUI Class Library Project Template:
+
+Similar to All-in-One .NET MAUI App, the Class Library project template also takes `target-platform` as a parameter that takes a combination from the same set of values (with `All` being the default value).
+
+* Can be created targeting .NET Razor SDK
+  - Parameter name: `--use-razor-sdk` | `-usr`
+* Can be created targeting .NET MAUI Core
+  - Parameter name: `--use-maui-core` | `-umc`
+* Can be created targeting .NET MAUI Essentials
+  - Parameter name: `--use-maui-essentials` | `-ume`
 
 #### Shared Class Library Project Template:
 
@@ -238,6 +253,28 @@ dotnet new mauiclasslib --help
 dotnet new sharedclasslib --help
 ```
 
+#### Partial Class Item Template:
+
+This item template (short name: `class-cs`) allows to create a C# class from CLI with support for multiple options.
+
+|Parameter Name|Type|Default Value|Remarks|
+|:--:|:---:|:---:|:---|
+access-modifier|choice|public|Specifies the accessibility of the class type.|
+base|text|object|Specifies the base type for the class.|
+abstract|bool|false|Option to create the type as abstract.|
+partial|bool|true|Option to create the type as partial.|
+sealed|bool|false|Option to create the type as sealed.|
+static|bool|false|Option to create the type as static.|
+
+Access Modifier parameter (`--access-modifier` | `-am`):
+
+Supported values are:
+
+* public (default value, if not provided)
+* internal
+* protected
+* private
+
 #### Usage:
 
 After installation, use the below command(s) to create new artifacts using the template (both provide the same output):
@@ -247,7 +284,13 @@ With parameter names abbreviated:
 
 .NET MAUI App:
 ```shell
+dotnet new mauiapp -n MyApp -dp Shell
+```
+```shell
 dotnet new mauiapp -n MyApp -dp Hybrid
+```
+```shell
+dotnet new mauiapp -n MyApp -dp Razor
 ```
 Option to include NuGet packages:
 ```shell
@@ -287,6 +330,9 @@ dotnet new maui-page -n LoginPage -na MyApp.Views
 ```shell
 dotnet new maui-page-cs -n HomePage -na MyApp.Views
 ```
+```shell
+dotnet new maui-page-razor -n HomePage
+```
 
 Views:
 ```shell
@@ -295,6 +341,9 @@ dotnet new maui-view -n CardView -na MyApp.Views
 ```shell
 dotnet new maui-view-cs -n OrderView -na MyApp.Views
 ```
+```shell
+dotnet new maui-view-razor -n OrderView
+```
 
 Shell:
 ```shell
@@ -302,6 +351,9 @@ dotnet new maui-shell -n AppShell -na MyApp
 ```
 ```shell
 dotnet new maui-shell-cs -n AppShell -na MyApp
+```
+```shell
+dotnet new maui-shell-razor -n AppShell
 ```
 
 Resource Dictionary:
@@ -314,14 +366,20 @@ Partial Class:
 dotnet new class-cs -n BaseViewModel -b ObservableObject
 ```
 ```shell
-dotnet new class-cs -n OrderDataStore -b IDataStore -p false
+dotnet new class-cs -n OrderDataStore -b IDataStore -p false -am internal
 ```
 
 With parameter names expanded:
 
 .NET MAUI App:
 ```shell
+dotnet new mauiapp --name MyApp --design-pattern Shell
+```
+```shell
 dotnet new mauiapp --name MyApp --design-pattern Hybrid
+```
+```shell
+dotnet new mauiapp --name MyApp --design-pattern Razor
 ```
 Option to include NuGet packages:
 ```shell
@@ -357,6 +415,9 @@ dotnet new maui-page --name LoginPage --namespace MyApp.Views
 ```shell
 dotnet new maui-page-cs --name HomePage --namespace MyApp.Views
 ```
+```shell
+dotnet new maui-page-razor --name HomePage
+```
 
 Views:
 ```shell
@@ -365,6 +426,9 @@ dotnet new maui-view --name CardView --namespace MyApp.Views
 ```shell
 dotnet new maui-view-cs --name OrderView --namespace MyApp.Views
 ```
+```shell
+dotnet new maui-view-razor --name OrderView
+```
 
 Shell:
 ```shell
@@ -372,6 +436,9 @@ dotnet new maui-shell --name AppShell --namespace MyApp
 ```
 ```shell
 dotnet new maui-shell-cs --name AppShell --namespace MyApp
+```
+```shell
+dotnet new maui-shell-razor --name AppShell
 ```
 
 Resource Dictionary:
@@ -384,5 +451,5 @@ Partial Class:
 dotnet new class-cs --name BaseViewModel
 ```
 ```shell
-dotnet new class-cs --name OrderDataStore --base IDataStore --partial false
+dotnet new class-cs --name OrderDataStore --base IDataStore --partial false --access-modifier internal
 ```

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,5 +1,31 @@
-What's new in ver. 3.1.0-preview.2:
+What's new in ver. 3.1.0-preview.3:
 -----------------------------------
+1. Fixed the build issue (#109) of .NET MAUI class library with .NET MAUI Essentials targeting the Windows platform.
+
+2. Added to option to create a .NET MAUI App using Razor syntax with BlazorBindings.Maui NuGet package.
+
+To facilitate this, the design-pattern parameter now takes the option of Razor.
+
+dotnet new mauiapp -o BlazorBindings -dp Razor
+
+dotnet new mauiapp -o BlazorBindings -f net8.0 -dp Razor
+
+3. Item templates for .NET MAUI ContentPage, ContentView and ShellPage using Razor syntax.
+
+dotnet new maui-page-razor -n SearchPage
+
+dotnet new maui-view-razor -n OrderView
+
+dotnet new maui-shell-razor -n AppShell
+
+4. Ability to set the access modifier (--access-modifier | --am) while creating a C# class from CLI.
+
+Default value is public.
+
+dotnet new class-cs -n Routes -am internal
+
+v3.1.0-preview.2:
+
 1. .NET MAUI App and Library project framework targets were restructured to better align with the development/build platforms.
 
 This enables to make use of the template without any modification across OS such as Windows, macOS, and Linux.

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,8 +1,8 @@
 What's new in ver. 3.1.0-preview.3:
 -----------------------------------
-1. Fixed the build issue (#109) of .NET MAUI class library with .NET MAUI Essentials targeting the Windows platform.
+1. Fixed the build issue (#109) of the .NET MAUI class library with .NET MAUI Essentials targeting the Windows platform.
 
-2. Added to option to create a .NET MAUI App using Razor syntax with BlazorBindings.Maui NuGet package.
+2. Added the option to create a .NET MAUI App using Razor syntax with BlazorBindings.Maui NuGet package.
 
 To facilitate this, the design-pattern parameter now takes the option of Razor.
 
@@ -10,7 +10,7 @@ dotnet new mauiapp -o BlazorBindings -dp Razor
 
 dotnet new mauiapp -o BlazorBindings -f net8.0 -dp Razor
 
-3. Item templates for .NET MAUI ContentPage, ContentView and ShellPage using Razor syntax.
+3. Item templates for .NET MAUI ContentPage, ContentView, and ShellPage using Razor syntax.
 
 dotnet new maui-page-razor -n SearchPage
 
@@ -20,7 +20,7 @@ dotnet new maui-shell-razor -n AppShell
 
 4. Ability to set the access modifier (--access-modifier | --am) while creating a C# class from CLI.
 
-Default value is public.
+The default value is public.
 
 dotnet new class-cs -n Routes -am internal
 


### PR DESCRIPTION
* Fixed the build issue (#109) of the .NET MAUI class library with .NET MAUI Essentials targeting the Windows platform.

* Added the option to create a .NET MAUI App using **Razor** syntax with [BlazorBindings.Maui](https://www.nuget.org/packages/BlazorBindings.Maui) NuGet package.

To facilitate this, the `design-pattern` parameter now takes the option of `Razor`.
```shell
dotnet new mauiapp -o BlazorBindings -dp Razor
```
```shell
dotnet new mauiapp -o BlazorBindings -f net8.0 -dp Razor
```

* Item templates for .NET MAUI ContentPage, ContentView, and ShellPage using Razor syntax.
```shell
dotnet new maui-page-razor -n SearchPage
```
```shell
dotnet new maui-view-razor -n OrderView
```
```shell
dotnet new maui-shell-razor -n AppShell
```

* Ability to set the **access modifier** (`--access-modifier` | `--am`) while creating a C# class from CLI.

The default value is `public`.
```shell
dotnet new class-cs -n Routes -am internal
```