### PR TITLE
Added support for MVU design pattern using Comet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,22 @@ Join me on [**Developer Thoughts**](https://egvijayanand.in/ "Developer Thoughts
 
 We all know that .NET MAUI is an evolution of Xamarin.Forms.
 
-Release Channel:
+Release Details:
 
-On .NET 6, `.NET MAUI SR10 (6.0.552)` and on .NET 7, `.NET MAUI SR3 (7.0.59)` is now released on Tue, Jan 31, 2023 along with VS2022 17.4.4
+|Channel|.NET MAUI Version|IDE Version|Release Date|
+|:---:|:---:|:---:|:---:|
+|Stable|.NET 6 SR10 (6.0.552)|VS2022 17.5.0|Tue, Jan 31, 2023|
+|Stable|.NET 7 SR3 (7.0.59)|VS2022 17.5.0|Tue, Jan 31, 2023|
+|Preview|.NET 8 Preview 1 (8.0.0-preview.1.7762)|VS2022 17.6.0 Preview 1.0|Tue, Feb 21, 2023|
 
-And on the Preview channel, `.NET MAUI 8.0.0-preview.1.7762 (.NET 8 Preview 1)` is now released on Tue, Feb 21, 2023 along with VS2022 17.6.0 Preview 1.0
+Use the below commands to verify the version installed:
+
+```shell
+dotnet --version
+```
+```shell
+dotnet workload list
+```
 
 Templates have been updated to support .NET 6/7/8 and is available to install from.
 
@@ -173,27 +184,7 @@ Both .NET MAUI *App* and *Class Library* templates take the below optional Boole
 * `-imt` | `--include-mvvm-toolkit` - Default is `false`
 * `-cc` | `--conditional-compilation` - Default is `false`
 
-Additional parameters for **App** project:
-
-MVVM is a delightful and development-friendly design pattern to work with. To support this, a new parameter has been introduced:
-
-* `-mvvm` | `--use-mvvm` - Default is `false`
-
-*Note: Opting for this MVVM option will not have any impact on the Web-based AppModels such as Blazor syntax (Hybrid) / Razor syntax.*
-
-The target for the Windows platform can be either `Package` (MSIX) or `Unpackaged`. By default, it is set as `Package`, this can be overridden while creating the project by including the below parameter:
-
-* `-wu` | `--windows-unpackaged` - Default is `false`
-
-While targeting `.NET 7` or later, an option to add and configure `CommunityToolkit.Maui.MediaElement`, `Microsoft.Maui.Controls.Foldable`, `Microsoft.Maui.Controls.Maps`, or all NuGet packages.
-
-* `-ime` | `--include-media-element` - Default is `false`
-* `-if` | `--include-foldable` - Default is `false`
-* `-inm` | `--include-maps` - Default is `false`
-
-*Note: If the project target `.NET 6`, selecting the MediaElement/Foldable/Maps option will NOT have any impact.*
-
-##### Conditional Compilation
+#### Conditional Compilation
 
 And now conditional compilation can be configured so that platform source files can be defined anywhere in the project provided they follow a naming convention as mentioned below. This will allow maintaining related source files in the same place, especially MAUI Handlers.
 
@@ -265,6 +256,7 @@ Can take any one of the following values, with default value set to `Plain`:
 |Hybrid|App configured to work in a Hybrid fashion using BlazorWebView.|
 |Markup|App configured to work with C# Markup syntax.|
 |Razor|App configured to work with Razor syntax.|
+|Comet|App configured to work with MVU pattern using Comet.|
 
 * `-tp` | `--target-platform`
 
@@ -284,6 +276,26 @@ Can take a combination of the following values, with default value set to `All`:
 |Apple|Targets iOS and macOS platforms.|
 
 ![Target Platform Options - Visual Studio](images/dotnetmaui-all-in-one-app-project-options.png)
+
+Additional parameters supported:
+
+MVVM is a delightful and development-friendly design pattern to work with. To support this, a new parameter has been introduced:
+
+* `-mvvm` | `--use-mvvm` - Default is `false`
+
+*Note: Opting for this MVVM option will not have any impact on the App created with Web-based Razor syntax or MVU based Comet.*
+
+The target for the Windows platform can be either `Package` (MSIX) or `Unpackaged`. By default, it is set as `Package`, this can be overridden while creating the project by including the below parameter:
+
+* `-wu` | `--windows-unpackaged` - Default is `false`
+
+While targeting `.NET 7` or later, an option to add and configure `CommunityToolkit.Maui.MediaElement`, `Microsoft.Maui.Controls.Foldable`, `Microsoft.Maui.Controls.Maps`, or all NuGet packages.
+
+* `-ime` | `--include-media-element` - Default is `false`
+* `-if` | `--include-foldable` - Default is `false`
+* `-inm` | `--include-maps` - Default is `false`
+
+*Note: If the project target `.NET 6`, selecting the MediaElement/Foldable/Maps option will NOT have any impact.*
 
 Examples (passing one or more values):
 
@@ -387,6 +399,9 @@ dotnet new mauiapp -n MyApp -dp Markup
 ```shell
 dotnet new mauiapp -n MyApp -dp Razor
 ```
+```shell
+dotnet new mauiapp -n MyApp -dp Comet
+```
 Option to use MVVM:
 ```shell
 dotnet new mauiapp -n MyApp -mvvm
@@ -485,6 +500,9 @@ dotnet new mauiapp --name MyApp --design-pattern Markup
 ```
 ```shell
 dotnet new mauiapp --name MyApp --design-pattern Razor
+```
+```shell
+dotnet new mauiapp --name MyApp --design-pattern Comet
 ```
 Option to use MVVM:
 ```shell

--- a/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
@@ -43,7 +43,7 @@
                     ]
                 },
                 {
-                    "condition": "(Xaml || Markup)",
+                    "condition": "(Xaml || Markup || Comet)",
                     "exclude": [
                         "**/Data/**",
                         "**/Pages/**",
@@ -67,10 +67,29 @@
                         "Controls/*.xaml.cs",
                         "Views/*.xaml",
                         "Views/*.xaml.cs",
+                        "Resources/*.cs",
                         "Resources/*.xaml"
                     ],
                     "rename": {
                         "App.razor.cs": "App.cs"
+                    }
+                },
+                {
+                    "condition": "(Comet)",
+                    "exclude": [
+                        "*.xaml",
+                        "*.xaml.cs",
+                        "Controls/*.xaml",
+                        "Controls/*.xaml.cs",
+                        "Helpers/*.cs",
+                        "Resources/*.cs",
+                        "Resources/*.xaml",
+                        "Views/*.xaml",
+                        "Views/*.xaml.cs"
+                    ],
+                    "rename": {
+                        "App.markup.cs": "App.cs",
+                        "Views/MainPage.markup.cs": "Views/MainPage.cs"
                     }
                 },
                 {
@@ -92,15 +111,14 @@
                     }
                 },
                 {
-                    "condition": "(!Markup)",
+                    "condition": "(!(Markup || Comet))",
                     "exclude": [
                         "**/*.markup.cs",
-                        "**/Resources/AppColors.cs",
-                        "**/Resources/AppStyles.cs"
+                        "Resources/*.cs"
                     ]
                 },
                 {
-                    "condition": "(!Mvvm || Hybrid || Razor)",
+                    "condition": "(!Mvvm || Razor || Comet)",
                     "exclude": [
                         "**/ViewModels/*",
                         "**/Exceptions/*",
@@ -154,7 +172,7 @@
                     ]
                 },
                 {
-                    "condition": "(Plain || Hybrid || Markup)",
+                    "condition": "(Plain || Hybrid || Markup || Comet)",
                     "exclude": [
                         "**/Exceptions/*",
                         "**/Models/*",
@@ -209,7 +227,8 @@
         "application-id": {
             "type": "parameter",
             "description": "Overrides the App Identifier of the project",
-            "datatype": "text"
+            "datatype": "text",
+            "defaultValue": "com.companyname.mauiappid"
         },
         "design-pattern": {
             "type": "parameter",
@@ -244,6 +263,10 @@
                 {
                     "choice": "Razor",
                     "description": "App configured to work with Razor syntax."
+                },
+                {
+                    "choice": "Comet",
+                    "description": "App configured to work with MVU pattern using Comet."
                 }
             ]
         },
@@ -371,7 +394,7 @@
                 "source": "application-id",
                 "toLower": true
             },
-            "replaces": "com.companyname.mauiAppId"
+            "replaces": "com.companyname.mauiappid"
         },
         "nameLower": {
             "type": "generated",
@@ -380,7 +403,10 @@
                 "source": "name",
                 "toLower": true
             },
-            "replaces": "mauiAppId"
+            "replaces": "mauiappid",
+            "onlyIf": {
+                "after": "appIdLower"
+            }
         },
         "designPatternLower": {
             "type": "generated",
@@ -433,6 +459,10 @@
         "Razor": {
             "type": "computed",
             "value": "(design-pattern == \"Razor\" || designPatternLower == \"razor\")"
+        },
+        "Comet": {
+            "type": "computed",
+            "value": "(design-pattern == \"Comet\" || designPatternLower == \"comet\")"
         },
         "Xaml": {
             "type": "computed",
@@ -524,7 +554,7 @@
         },
         "PackageRef": {
             "type": "computed",
-            "value": "(AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater || Razor)"
+            "value": "(AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater || Razor || Comet)"
         },
         "HostIdentifier": {
             "type": "bind",

--- a/src/MauiTemplatesCLI/MauiAppX/App.markup.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/App.markup.cs
@@ -1,8 +1,22 @@
 ﻿namespace MauiApp._1
 {
+#if Comet
+    public partial class App : CometApp
+    {   
+        public App(IServiceProvider services) => Body = services.GetRequiredService<MainPage>;
+
+        #region AppDefaults
+        public static Color AppColor => Color.FromArgb("#512BD4");
+            
+        public static string AppFont => "OpenSansRegular";
+    
+        public static double AppFontSize => 14d;
+        #endregion
+    }
+#endif
+#if Markup
     public partial class App : Application
     {
-#if Markup
 #if Mvvm
         public App(IServiceProvider services)
 #else
@@ -57,6 +71,6 @@
             MainPage = new MainPage();
 #endif
         }
-#endif
     }
+#endif
 }

--- a/src/MauiTemplatesCLI/MauiAppX/App.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/App.xaml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.App">
+<Application
+        x:Class="MauiApp._1.App"
+        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="clr-namespace:MauiApp._1">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -10,7 +11,7 @@
                 <ResourceDictionary Source="Resources/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Additional Styles -->
-            <!--#if (!(Plain && Hybrid))-->
+            <!--#if (!(Plain || Hybrid))-->
             <Thickness x:Key="ApplePadding">30,60,30,30</Thickness>
             <Thickness x:Key="DefaultPadding">30</Thickness>
             <!--#endif-->

--- a/src/MauiTemplatesCLI/MauiAppX/App.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/App.xaml.cs
@@ -15,6 +15,7 @@
         public App()
 #else
         public App(IServiceProvider services)
+#endif
         {
             InitializeComponent();
 
@@ -28,10 +29,9 @@
             MainPage = new MainPage();
 #endif
         }
-
 #if (Hierarchical || Tabbed)
+
         public static IDictionary<string, Type> Routes => _routes;
-#endif
 #endif
 #else
         public App()

--- a/src/MauiTemplatesCLI/MauiAppX/App.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/App.xaml.cs
@@ -3,7 +3,7 @@
     public partial class App : Application
     {
 #if (!Markup)
-#if (Mvvm && !(Hybrid || Razor))
+#if (Mvvm && !Razor)
 #if (Hierarchical || Tabbed)
         private static readonly Dictionary<string, Type> _routes = new()
         {
@@ -11,33 +11,42 @@
         };
 
 #endif
-#if (Tabbed)
+#if (Tabbed || Shell)
         public App()
 #else
         public App(IServiceProvider services)
-#endif
-#else
-        public App()
-#endif
         {
             InitializeComponent();
 
-#if (Hierarchical && Mvvm)
+#if Hierarchical
             MainPage = new NavigationPage(services.GetService<MainPage>());
-#elif Hierarchical
+#elif (Plain || Hybrid || Markup)
+            MainPage = services.GetService<MainPage>();
+#elif Shell
+            MainPage = new AppShell();
+#else
+            MainPage = new MainPage();
+#endif
+        }
+
+#if (Hierarchical || Tabbed)
+        public static IDictionary<string, Type> Routes => _routes;
+#endif
+#endif
+#else
+        public App()
+        {
+            InitializeComponent();
+
+#if Hierarchical
             MainPage = new NavigationPage(new MainPage());
 #elif Shell
             MainPage = new AppShell();
-#elif ((Plain || Markup) && Mvvm)
-            MainPage = services.GetService<MainPage>();
 #else
             MainPage = new MainPage();
 #endif
         }
 #endif
-
-#if ((Hierarchical || Tabbed) && Mvvm)
-        public static IDictionary<string, Type> Routes => _routes;
 #endif
     }
 }

--- a/src/MauiTemplatesCLI/MauiAppX/Imports.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Imports.cs
@@ -1,5 +1,21 @@
+#if Comet
+global using System;
+global using Microsoft.Extensions.DependencyInjection;
+
+#endif
 #if Razor
 global using BlazorBindings.Maui;
+
+#endif
+#if Comet
+// .NET MAUI
+global using Microsoft.Maui;
+global using Microsoft.Maui.Accessibility;
+global using Microsoft.Maui.Graphics;
+global using Microsoft.Maui.Hosting;
+
+// Comet
+global using Comet;
 
 #endif
 #if AddToolkitPackage
@@ -7,7 +23,7 @@ global using BlazorBindings.Maui;
 global using CommunityToolkit.Maui;
 
 #endif
-#if (AddMvvmToolkitPackage || (Mvvm && !(Hybrid || Razor)))
+#if (AddMvvmToolkitPackage || (Mvvm && !Razor))
 // MVVM Toolkit
 global using CommunityToolkit.Mvvm.ComponentModel;
 global using CommunityToolkit.Mvvm.Input;
@@ -16,7 +32,7 @@ global using CommunityToolkit.Mvvm.Input;
 #if (Hierarchical || Tabbed || Shell)
 global using MauiApp._1.Controls;
 #endif
-#if (Mvvm && !(Hybrid || Razor))
+#if (Mvvm && !(Razor || Comet))
 #if (Hierarchical || Tabbed || Shell)
 #if (!Shell)
 global using MauiApp._1.Exceptions;
@@ -42,4 +58,8 @@ global using static MauiApp._1.Helpers.VisualStateHelper;
 #else
 // Static
 global using static Microsoft.Maui.Graphics.Colors;
+#if Comet
+global using static Microsoft.Maui.TextAlignment;
+global using static MauiApp._1.App;
+#endif
 #endif

--- a/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
@@ -99,7 +99,9 @@
 
         <!-- Project Options -->
         <Nullable>enable</Nullable>
+        <!--#if (!Comet)-->
         <ImplicitUsings>enable</ImplicitUsings>
+        <!--#endif-->
         <RootNamespace>MauiApp._1</RootNamespace>
         <!--#if (Unpackaged)-->
         <WindowsPackageType>None</WindowsPackageType>
@@ -109,7 +111,7 @@
         <ApplicationTitle>MauiApp.1</ApplicationTitle>
 
         <!-- App Identifier -->
-        <ApplicationId>com.companyname.mauiAppId</ApplicationId>
+        <ApplicationId>com.companyname.mauiappid</ApplicationId>
         <ApplicationIdGuid>81a9fb0a-63f5-4ef6-b38e-0cf88600102a</ApplicationIdGuid>
 
         <!-- Versions -->
@@ -155,6 +157,9 @@
         <!--#if (Razor)-->
         <PackageReference Include="BlazorBindings.Maui" Version="1.0.1" />
         <!--#endif-->
+        <!--#if (Comet)-->
+        <PackageReference Include="Clancey.Comet" Version="0.3.467-beta" />
+        <!--#endif-->
         <!--#if (AddFoldablePackage)-->
         <PackageReference Include="Microsoft.Maui.Controls.Foldable" Version="7.0.52" />
         <!--#endif-->
@@ -184,7 +189,7 @@
         <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.2.1"/>
         <!--#endif-->
         <!--#endif-->
-        <!--#if (AddMvvmToolkitPackage || (Mvvm && !(Hybrid || Razor)))-->
+        <!--#if (AddMvvmToolkitPackage || (Mvvm && !Razor))-->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0"/>
         <!--#endif-->
     <!--#if (PackageRef)-->

--- a/src/MauiTemplatesCLI/MauiAppX/MauiProgram.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiProgram.cs
@@ -23,7 +23,11 @@ namespace MauiApp._1
         public static MauiApp CreateMauiApp()
         {
             var builder = MauiApp.CreateBuilder();
+#if Comet
+            builder.UseCometApp<App>()
+#else
             builder.UseMauiApp<App>()
+#endif
 #if Razor
                    .UseMauiBlazorBindings()
 #endif
@@ -44,12 +48,25 @@ namespace MauiApp._1
 #endif
                    .ConfigureFonts(fonts =>
                    {
+#if Comet
+                       fonts.AddFont("OpenSans-Regular.ttf", AppFont);
+#else
                        fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+#endif
                        fonts.AddFont("OpenSans-SemiBold.ttf", "OpenSansSemiBold");
                    });
 
-#if (Mvvm && !(Hybrid || Razor))
-#if (Plain || Markup)
+#if (Comet)
+            builder.Services.AddSingleton(SemanticScreenReader.Default);
+            builder.Services.AddSingleton<MainPage>();
+
+#endif
+#if (Mvvm && !(Razor || Comet))
+#if Hybrid
+            builder.Services.AddSingleton<MainViewModel>();
+            builder.Services.AddSingleton<MainPage>();
+
+#elif (Plain || Markup)
             builder.Services.AddSingleton(SemanticScreenReader.Default);
             builder.Services.AddSingleton<MainViewModel>();
             builder.Services.AddSingleton<MainPage>();
@@ -89,10 +106,10 @@ namespace MauiApp._1
 #endif
 #if Hybrid
             builder.Services.AddMauiBlazorWebView();
-            // Caution: Recommended to enable Developer Tools only for development!!!
 #if Net7OrLater
 //-:cnd:noEmit
 #if DEBUG
+            // Caution: Recommended to enable Developer Tools only for development!!!
             builder.Services.AddBlazorWebViewDeveloperTools();
             builder.Logging.AddDebug();
 #endif

--- a/src/MauiTemplatesCLI/MauiAppX/Platforms/Tizen/tizen-manifest.xml
+++ b/src/MauiTemplatesCLI/MauiAppX/Platforms/Tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<manifest package="com.companyname.mauiAppId" version="1.0.0" api-version="7" xmlns="http://tizen.org/ns/packages">
+<manifest package="com.companyname.mauiappid" version="1.0.0" api-version="7" xmlns="http://tizen.org/ns/packages">
   <profile name="common" />
-  <ui-application appid="com.companyname.mauiAppId" exec="MauiApp.1.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+  <ui-application appid="com.companyname.mauiappid" exec="MauiApp.1.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
     <label>MauiApp.1</label>
     <icon>appicon.xhigh.png</icon>
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />

--- a/src/MauiTemplatesCLI/MauiAppX/ViewModels/BaseViewModel.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/ViewModels/BaseViewModel.cs
@@ -2,7 +2,7 @@
 {
     public partial class BaseViewModel : ObservableObject
     {
-#if (Plain || Markup)
+#if (Plain || Hybrid || Markup)
         public BaseViewModel()
         {
             

--- a/src/MauiTemplatesCLI/MauiAppX/ViewModels/MainViewModel.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/ViewModels/MainViewModel.cs
@@ -2,7 +2,12 @@
 {
     public partial class MainViewModel : BaseViewModel
     {
-#if (Plain || Markup)
+#if Hybrid
+        public MainViewModel()
+        {
+            Title = "Home";
+        }
+#elif (Plain || Markup)
         private int count = 0;
         private readonly ISemanticScreenReader _screenReader;
 

--- a/src/MauiTemplatesCLI/MauiAppX/Views/EventsPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/EventsPage.xaml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Mvvm)-->
-<ContentPage x:Class="MauiApp._1.Views.EventsPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             x:DataType="vm:EventsViewModel">
+<ContentPage
+    x:Class="MauiApp._1.Views.EventsPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    x:DataType="vm:EventsViewModel">
     <ContentPage.Content>
         <StackLayout HorizontalOptions="Center"
                      VerticalOptions="Center">
@@ -18,10 +19,11 @@
     </ContentPage.Content>
 </ContentPage>
 <!--#else-->
-<ContentPage x:Class="MauiApp._1.Views.EventsPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1">
+<ContentPage
+    x:Class="MauiApp._1.Views.EventsPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1">
     <ContentPage.Content>
         <StackLayout HorizontalOptions="Center"
                      VerticalOptions="Center">

--- a/src/MauiTemplatesCLI/MauiAppX/Views/LoginPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/LoginPage.xaml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Mvvm)-->
-<ContentPage x:Class="MauiApp._1.Views.LoginPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             Shell.NavBarIsVisible="False"
-             x:DataType="vm:LoginViewModel">
+<ContentPage
+    x:Class="MauiApp._1.Views.LoginPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Shell.NavBarIsVisible="False"
+    x:DataType="vm:LoginViewModel">
     <StackLayout HorizontalOptions="Center"
                  VerticalOptions="Center">
         <Button Command="{Binding LoginCommand}"
@@ -15,11 +16,12 @@
     </StackLayout>
 </ContentPage>
 <!--#else-->
-<ContentPage x:Class="MauiApp._1.Views.LoginPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             Shell.NavBarIsVisible="False">
+<ContentPage
+    x:Class="MauiApp._1.Views.LoginPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    Shell.NavBarIsVisible="False">
     <StackLayout HorizontalOptions="Center"
                  VerticalOptions="Center">
         <Button Style="{StaticResource PrimaryAction}"

--- a/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.markup.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.markup.cs
@@ -1,5 +1,49 @@
 ﻿namespace MauiApp._1.Views
 {
+#if Comet
+    public partial class MainPage : View
+    {
+        private int count = 0;
+        private readonly State<string> countText = "Current count: 0";
+        private readonly ISemanticScreenReader _screenReader;
+
+        public MainPage(ISemanticScreenReader screenReader)
+        {
+            _screenReader = screenReader;
+            Body = Build;
+        }
+
+        View Build() => new ScrollView()
+        {
+            new VStack(spacing: 25)
+            {
+                new Text(() => "Hello, World!").FontFamily(() => AppFont)
+                                               .FontSize(32)
+                                               .Color(() => AppColor),
+                new Text(() => "Welcome to .NET Multi-platform App UI").FontFamily(() => AppFont)
+                                                                       .FontSize(18)
+                                                                       .Color(() => AppColor),
+                new Text(countText).FontFamily(() => AppFont)
+                                   .FontSize(18)
+                                   .FontWeight(FontWeight.Bold)
+                                   .Color(() => AppColor),
+                new Button("Click me", IncrementCount).FontFamily(() => AppFont)
+                                                 .FontSize(AppFontSize)
+                                                 .Background(() => AppColor)
+                                                 .Color(() => White)
+                                                 .Padding(new Thickness(14, 10)),
+                new Image(() => "dotnet_bot.png")
+            }.Padding(30)
+        };
+
+        private void IncrementCount()
+        {
+            count++;
+            countText.Value = $"Current count: {count}";
+            _screenReader.Announce(countText.Value);
+        }
+    }
+#endif
 #if Markup
     public partial class MainPage : ContentPage
     {

--- a/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Hybrid)-->
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.Views.MainPage">
+<!--#if (Mvvm)-->
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Title="{Binding Title}"
+    x:DataType="vm:MainViewModel">
 
     <BlazorWebView HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>
@@ -12,14 +17,30 @@
     </BlazorWebView>
 
 </ContentPage>
+<!--#else-->
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1">
+
+    <BlazorWebView HostPage="wwwroot/index.html">
+        <BlazorWebView.RootComponents>
+            <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
+        </BlazorWebView.RootComponents>
+    </BlazorWebView>
+
+</ContentPage>
+<!--#endif-->
 <!--#elif (Tabbed)-->
-<TabbedPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:android="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;assembly=Microsoft.Maui.Controls"
-            xmlns:local="clr-namespace:MauiApp._1"
-            xmlns:vw="clr-namespace:MauiApp._1.Views"
-            x:Class="MauiApp._1.Views.MainPage"
-            android:TabbedPage.ToolbarPlacement="Bottom">
+<TabbedPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:android="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;assembly=Microsoft.Maui.Controls"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vw="clr-namespace:MauiApp._1.Views"
+    android:TabbedPage.ToolbarPlacement="Bottom">
     <NavigationPage x:Name="calendar"
                     Title="Calendar">
         <x:Arguments>
@@ -31,13 +52,14 @@
 </TabbedPage>
 <!--#elif (Hierarchical)-->
 <!--#if (Mvvm)-->
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             x:Class="MauiApp._1.Views.MainPage"
-             Title="{Binding Title}"
-             x:DataType="vm:MainViewModel">
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Title="{Binding Title}"
+    x:DataType="vm:MainViewModel">
     <ContentPage.Content>
         <StackLayout HorizontalOptions="Center"
                      VerticalOptions="Center">
@@ -50,11 +72,12 @@
     </ContentPage.Content>
 </ContentPage>
 <!--#else-->
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.Views.MainPage"
-             Title="Calendar">
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    Title="Calendar">
     <ContentPage.Content>
         <StackLayout HorizontalOptions="Center"
                      VerticalOptions="Center">
@@ -69,18 +92,20 @@
 <!--#endif-->
 <!--#else-->
 <!--#if (Mvvm)-->
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             x:Class="MauiApp._1.Views.MainPage"
-             x:DataType="vm:MainViewModel"
-             Title="{Binding Title}">
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Title="{Binding Title}"
+    x:DataType="vm:MainViewModel">
 <!--#else-->
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             x:Class="MauiApp._1.Views.MainPage">
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1">
 <!--#endif-->
 
     <ScrollView>

--- a/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml.cs
@@ -9,14 +9,14 @@
 #if (Plain && !Mvvm)
         private int count = 0;
 #endif
-#if (Mvvm && !(Tabbed || Hybrid))
+#if (Mvvm && !Tabbed)
         public MainPage(MainViewModel viewModel)
 #else
         public MainPage()
 #endif
         {
             InitializeComponent();
-#if (Mvvm && !(Tabbed || Hybrid))
+#if (Mvvm && !Tabbed)
             BindingContext = viewModel;
 #endif
         }

--- a/src/MauiTemplatesCLI/MauiAppX/Views/NewEventPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/NewEventPage.xaml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Mvvm)-->
-<ContentPage x:Class="MauiApp._1.Views.NewEventPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:ctrl="clr-namespace:MauiApp._1.Controls"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             Title="{Binding Title}"
-             Shell.PresentationMode="ModalAnimated"
-             Padding="{OnPlatform iOS={StaticResource ApplePadding},
-                                  Default={StaticResource DefaultPadding}}"
-             x:DataType="vm:NewEventViewModel">
+<ContentPage
+    x:Class="MauiApp._1.Views.NewEventPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:ctrl="clr-namespace:MauiApp._1.Controls"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Padding="{OnPlatform iOS={StaticResource ApplePadding},
+                         Default={StaticResource DefaultPadding}}"
+    Shell.PresentationMode="ModalAnimated"
+    Title="{Binding Title}"
+    x:DataType="vm:NewEventViewModel">
     <ContentPage.Content>
         <StackLayout>
             <Entry Text="{Binding Event.Name}"
@@ -44,16 +45,18 @@
     </ContentPage.Content>
 </ContentPage>
 <!--#else-->
-<ContentPage x:Class="MauiApp._1.Views.NewEventPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:ctrl="clr-namespace:MauiApp._1.Controls"
-             Title="New Event"
-             Shell.PresentationMode="ModalAnimated"
-             Padding="{OnPlatform iOS={StaticResource ApplePadding},
-                                  Default={StaticResource DefaultPadding}}">
+<ContentPage
+    x:Class="MauiApp._1.Views.NewEventPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:ctrl="clr-namespace:MauiApp._1.Controls"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Padding="{OnPlatform iOS={StaticResource ApplePadding},
+                         Default={StaticResource DefaultPadding}}"
+    Shell.PresentationMode="ModalAnimated"
+    Title="New Event">
     <ContentPage.Content>
         <StackLayout>
             <Entry Text=""

--- a/src/MauiTemplatesCLI/MauiAppX/Views/SearchPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/SearchPage.xaml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Mvvm)-->
-<ContentPage x:Class="MauiApp._1.Views.SearchPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             Title="{Binding Title}"
-             x:DataType="vm:SearchViewModel">
+<ContentPage
+    x:Class="MauiApp._1.Views.SearchPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Title="{Binding Title}"
+    x:DataType="vm:SearchViewModel">
 <!--#else-->
-<ContentPage x:Class="MauiApp._1.Views.SearchPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             Title="Search">
+<ContentPage
+    x:Class="MauiApp._1.Views.SearchPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    Title="Search">
 <!--#endif-->
-    <Label Text="Search"
-           HorizontalOptions="Center"
-           VerticalOptions="Center" />
+    <Label
+        HorizontalOptions="Center"
+        Text="Search"
+        VerticalOptions="Center" />
 </ContentPage>

--- a/src/MauiTemplatesCLI/MauiAppX/Views/SettingsPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/SettingsPage.xaml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Mvvm)-->
-<ContentPage x:Class="MauiApp._1.Views.SettingsPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-             Title="{Binding Title}"
-             x:DataType="vm:SettingsViewModel">
+<ContentPage
+    x:Class="MauiApp._1.Views.SettingsPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Title="{Binding Title}"
+    x:DataType="vm:SettingsViewModel">
 <!--#else-->
-<ContentPage x:Class="MauiApp._1.Views.SettingsPage"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MauiApp._1"
-             Title="Settings">
+<ContentPage
+    x:Class="MauiApp._1.Views.SettingsPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiApp._1"
+    Title="Settings">
 <!--#endif-->
-    <Label Text="Settings"
-           HorizontalOptions="Center"
-           VerticalOptions="Center" />
+    <Label
+        HorizontalOptions="Center"
+        Text="Settings"
+        VerticalOptions="Center" />
 </ContentPage>

--- a/src/MauiTemplatesCLI/MauiPage/MauiPage.1.xaml
+++ b/src/MauiTemplatesCLI/MauiPage/MauiPage.1.xaml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<ContentPage x:Class="MyApp.Namespace.MauiPage__1"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MyApp.Namespace">
+<ContentPage
+    x:Class="MyApp.Namespace.MauiPage__1"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MyApp.Namespace">
     <ContentPage.Content>
         <Grid>
-            <Label Text="Welcome to .NET MAUI!!!"
-                   TextColor="Purple"
-                   HorizontalOptions="Center"
-                   VerticalOptions="Center"/>
+            <Label
+                HorizontalOptions="Center"
+                Text="Welcome to .NET MAUI!!!"
+                TextColor="Purple"
+                VerticalOptions="Center" />
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/src/MauiTemplatesCLI/MauiResDict/MauiResDict.1.xaml
+++ b/src/MauiTemplatesCLI/MauiResDict/MauiResDict.1.xaml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (NoCodeBehind || XamlOnly)-->
 <?xaml-comp compile="true" ?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                    xmlns:local="clr-namespace:MyApp.Namespace">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MyApp.Namespace">
     <!-- Define your resources here -->
 </ResourceDictionary>
 <!--#else-->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                    xmlns:local="clr-namespace:MyApp.Namespace"
-                    x:Class="MyApp.Namespace.MauiResDict__1">
+<ResourceDictionary
+    x:Class="MyApp.Namespace.MauiResDict__1"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MyApp.Namespace">
     <!-- Define your resources here -->
 </ResourceDictionary>
 <!--#endif-->

--- a/src/MauiTemplatesCLI/MauiShell/MauiShell.1.xaml
+++ b/src/MauiTemplatesCLI/MauiShell/MauiShell.1.xaml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<Shell x:Class="MyApp.Namespace.MauiShell__1"
-       xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-       xmlns:local="clr-namespace:MyApp.Namespace">
+<Shell
+    x:Class="MyApp.Namespace.MauiShell__1"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MyApp.Namespace">
     <!--
         The overall app visual hierarchy is defined here, along with navigation.
         Ensure atleast a Flyout item or a TabBar is defined for Shell to work

--- a/src/MauiTemplatesCLI/MauiView/MauiView.1.xaml
+++ b/src/MauiTemplatesCLI/MauiView/MauiView.1.xaml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<ContentView x:Class="MyApp.Namespace.MauiView__1"
-             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:local="clr-namespace:MyApp.Namespace">
+<ContentView
+    x:Class="MyApp.Namespace.MauiView__1"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MyApp.Namespace">
     <ContentView.Content>
         <Grid>
-            <Label Text="Welcome to .NET MAUI!!!"
-                   TextColor="Purple"
-                   HorizontalOptions="Center"
-                   VerticalOptions="Center"/>
+            <Label
+                HorizontalOptions="Center"
+                Text="Welcome to .NET MAUI!!!"
+                TextColor="Purple"
+                VerticalOptions="Center" />
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.1.0-preview.5
+3.1.0-preview.6

--- a/src/MauiTemplatesCLI/overview.md
+++ b/src/MauiTemplatesCLI/overview.md
@@ -92,28 +92,7 @@ Both .NET MAUI *App* and *Class Library* templates take the below optional Boole
 * `-imt` | `--include-mvvm-toolkit` - Default is `false`
 * `-cc` | `--conditional-compilation` - Default is `false`
 
-Additional parameters for **App** project:
-
-MVVM is a delightful and development-friendly design pattern to work with. To support this, a new parameter has been introduced:
-
-* `-mvvm` | `--use-mvvm` - Default is `false`
-
-*Note: Opting for this MVVM option will not have any impact on the Web-based AppModels such as Blazor syntax (Hybrid) / Razor syntax.*
-
-The target for the Windows platform can be either `Package` (MSIX) or `Unpackaged`. By default, it is set as `Package`, this can be overridden while creating the project by including the below parameter:
-
-
-* `-wu` | `--windows-unpackaged` - Default is `false`
-
-While targeting `.NET 7` or later, an option to add and configure `CommunityToolkit.Maui.MediaElement`, `Microsoft.Maui.Controls.Foldable`, `Microsoft.Maui.Controls.Maps`, or all NuGet packages.
-
-* `-ime` | `--include-media-element` - Default is `false`
-* `-if` | `--include-foldable` - Default is `false`
-* `-inm` | `--include-maps` - Default is `false`
-
-*Note: If the project target `.NET 6`, selecting the MediaElement/Foldable/Maps option will NOT have any impact.*
-
-##### Conditional Compilation
+#### Conditional Compilation
 
 And now conditional compilation can be configured so that platform source files can be defined anywhere in the project provided they follow a naming convention as mentioned below. This will allow maintaining related source files in the same place, especially MAUI Handlers.
 
@@ -185,6 +164,7 @@ Can take any one of the following values, with default value set to `Plain`:
 |Hybrid|App configured to work in a Hybrid fashion using BlazorWebView.|
 |Markup|App configured to work with C# Markup syntax.|
 |Razor|App configured to work with Razor syntax.|
+|Comet|App configured to work with MVU pattern using Comet.|
 
 * `-tp` | `--target-platform`
 
@@ -202,6 +182,26 @@ Can take a combination of the following values, with default value set to `All`:
 |Mobile|Targets Android and iOS platforms.|
 |Desktop|Targets Windows and macOS platforms.|
 |Apple|Targets iOS and macOS platforms.|
+
+Additional parameters supported:
+
+MVVM is a delightful and development-friendly design pattern to work with. To support this, a new parameter has been introduced:
+
+* `-mvvm` | `--use-mvvm` - Default is `false`
+
+*Note: Opting for this MVVM option will not have any impact on the App created with Web-based Razor syntax or MVU based Comet.*
+
+The target for the Windows platform can be either `Package` (MSIX) or `Unpackaged`. By default, it is set as `Package`, this can be overridden while creating the project by including the below parameter:
+
+* `-wu` | `--windows-unpackaged` - Default is `false`
+
+While targeting `.NET 7` or later, an option to add and configure `CommunityToolkit.Maui.MediaElement`, `Microsoft.Maui.Controls.Foldable`, `Microsoft.Maui.Controls.Maps`, or all NuGet packages.
+
+* `-ime` | `--include-media-element` - Default is `false`
+* `-if` | `--include-foldable` - Default is `false`
+* `-inm` | `--include-maps` - Default is `false`
+
+*Note: If the project target `.NET 6`, selecting the MediaElement/Foldable/Maps option will NOT have any impact.*
 
 Examples:
 
@@ -303,6 +303,9 @@ dotnet new mauiapp -n MyApp -dp Markup
 ```shell
 dotnet new mauiapp -n MyApp -dp Razor
 ```
+```shell
+dotnet new mauiapp -n MyApp -dp Comet
+```
 Option to use MVVM:
 ```shell
 dotnet new mauiapp -n MyApp -mvvm
@@ -401,6 +404,9 @@ dotnet new mauiapp --name MyApp --design-pattern Markup
 ```
 ```shell
 dotnet new mauiapp --name MyApp --design-pattern Razor
+```
+```shell
+dotnet new mauiapp --name MyApp --design-pattern Comet
 ```
 Option to use MVVM:
 ```shell

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,5 +1,19 @@
-What's new in ver. 3.1.0-preview.5:
+What's new in ver. 3.1.0-preview.6:
 -----------------------------------
+1. Now MVVM option works with an App created with a Hybrid design pattern also.
+
+dotnet new mauiapp -o MyApp -dp Hybrid -mvvm
+
+2. Added the option to create a .NET MAUI App with the MVU pattern using Comet.
+
+To facilitate this, the design-pattern parameter now takes the option of Comet.
+
+dotnet new mauiapp -o MyApp -dp Comet
+
+Note: MVVM option won't have any impact on the App created with Comet option as it is based on the MVU design pattern.
+
+v3.1.0-preview.5:
+
 1. MVVM is a delightful and development-friendly design pattern to work with. To support this, a new parameter has been introduced:
 
 -mvvm | --use-mvvm and its default value is false.

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -10,6 +10,8 @@ To facilitate this, the design-pattern parameter now takes the option of Comet.
 
 dotnet new mauiapp -o MyApp -dp Comet
 
+Since this Comet is still in the PoC stage and no published roadmap for future updates. So, try it at your own risk.
+
 Note: MVVM option won't have any impact on the App created with Comet option as it is based on the MVU design pattern.
 
 v3.1.0-preview.5:


### PR DESCRIPTION
* Now MVVM option works with an App created with a **Hybrid** design pattern also.
```shell
dotnet new mauiapp -o MyApp -dp Hybrid -mvvm
```
* Added the option to create a .NET MAUI App with the **MVU pattern using Comet**.

To facilitate this, the design-pattern parameter now takes the option of **Comet**.
```shell
dotnet new mauiapp -o MyApp -dp Comet
```
_Note: The MVVM option won't have any impact on the App created with the Comet option as it is based on the MVU design pattern._