### PR TITLE
Added support for MVU design pattern using Reactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Release Details:
 
 |Channel|.NET MAUI Version|IDE Version|Release Date|
 |:---:|:---:|:---:|:---:|
-|Stable|.NET 6 SR10 (6.0.552)|VS2022 17.5.0|Tue, Jan 31, 2023|
-|Stable|.NET 7 SR3 (7.0.59)|VS2022 17.5.0|Tue, Jan 31, 2023|
-|Preview|.NET 8 Preview 1 (8.0.0-preview.1.7762)|VS2022 17.6.0 Preview 1.0|Tue, Feb 21, 2023|
+|Stable|.NET 6 SR10 (6.0.552)|VS2022 17.4.x/17.5.x|Tue, Jan 31, 2023|
+|Stable|.NET 7 SR3 (7.0.59)|VS2022 17.4.x/17.5.x|Tue, Jan 31, 2023|
+|Preview|.NET 8 Preview 2 (8.0.0-preview.2.7871)|VS2022 17.6.0 Preview 2.0|Tue, Mar 14, 2023|
 
 Use the below commands to verify the version installed:
 
@@ -257,6 +257,7 @@ Can take any one of the following values, with default value set to `Plain`:
 |Markup|App configured to work with C# Markup syntax.|
 |Razor|App configured to work with Razor syntax.|
 |Comet|App configured to work with MVU pattern using Comet.|
+|Reactor|App configured to work with MVU pattern using Reactor.|
 
 * `-tp` | `--target-platform`
 
@@ -402,6 +403,9 @@ dotnet new mauiapp -n MyApp -dp Razor
 ```shell
 dotnet new mauiapp -n MyApp -dp Comet
 ```
+```shell
+dotnet new mauiapp -n MyApp -dp Reactor
+```
 Option to use MVVM:
 ```shell
 dotnet new mauiapp -n MyApp -mvvm
@@ -503,6 +507,9 @@ dotnet new mauiapp --name MyApp --design-pattern Razor
 ```
 ```shell
 dotnet new mauiapp --name MyApp --design-pattern Comet
+```
+```shell
+dotnet new mauiapp --name MyApp --design-pattern Reactor
 ```
 Option to use MVVM:
 ```shell

--- a/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
@@ -43,7 +43,7 @@
                     ]
                 },
                 {
-                    "condition": "(Xaml || Markup || Comet)",
+                    "condition": "(Xaml || CSharp)",
                     "exclude": [
                         "**/Data/**",
                         "**/Pages/**",
@@ -93,6 +93,24 @@
                     }
                 },
                 {
+                    "condition": "(Reactor)",
+                    "exclude": [
+                        "*.xaml",
+                        "*.xaml.cs",
+                        "App.markup.cs",
+                        "Controls/*.xaml",
+                        "Controls/*.xaml.cs",
+                        "Resources/*.cs",
+                        "Views/*.xaml",
+                        "Views/*.xaml.cs"
+                    ],
+                    "rename": {
+                        "Views/MainPage.markup.cs": "Views/MainPage.cs",
+                        "Helpers/ResourceHelper.markup.cs": "Helpers/ResourceHelper.cs",
+                        "Helpers/VisualStateHelper.markup.cs": "Helpers/VisualStateHelper.cs"
+                    }
+                },
+                {
                     "condition": "(Markup)",
                     "exclude": [
                         "*.xaml",
@@ -111,14 +129,20 @@
                     }
                 },
                 {
-                    "condition": "(!(Markup || Comet))",
+                    "condition": "(!CSharp)",
                     "exclude": [
                         "**/*.markup.cs",
                         "Resources/*.cs"
                     ]
                 },
                 {
-                    "condition": "(!Mvvm || Razor || Comet)",
+                    "condition": "(!Reactor)",
+                    "exclude": [
+                        "Resources/AppStyles.xaml"
+                    ]
+                },
+                {
+                    "condition": "(!Mvvm || Razor || Mvu)",
                     "exclude": [
                         "**/ViewModels/*",
                         "**/Exceptions/*",
@@ -172,7 +196,7 @@
                     ]
                 },
                 {
-                    "condition": "(Plain || Hybrid || Markup || Comet)",
+                    "condition": "(Plain || Hybrid || CSharp)",
                     "exclude": [
                         "**/Exceptions/*",
                         "**/Models/*",
@@ -267,6 +291,10 @@
                 {
                     "choice": "Comet",
                     "description": "App configured to work with MVU pattern using Comet."
+                },
+                {
+                    "choice": "Reactor",
+                    "description": "App configured to work with MVU pattern using Reactor."
                 }
             ]
         },
@@ -464,6 +492,14 @@
             "type": "computed",
             "value": "(design-pattern == \"Comet\" || designPatternLower == \"comet\")"
         },
+        "Reactor": {
+            "type": "computed",
+            "value": "(design-pattern == \"Reactor\" || designPatternLower == \"reactor\")"
+        },
+        "CSharp": {
+            "type": "computed",
+            "value": "(Markup || Mvu)"
+        },
         "Xaml": {
             "type": "computed",
             "value": "(Plain || Hierarchical || Tabbed || Shell)"
@@ -471,6 +507,10 @@
         "Mvvm": {
             "type": "computed",
             "value": "(use-mvvm)"
+        },
+        "Mvu": {
+            "type": "computed",
+            "value": "(Comet || Reactor)"
         },
         "Net7": {
             "type": "computed",
@@ -554,7 +594,7 @@
         },
         "PackageRef": {
             "type": "computed",
-            "value": "(AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater || Razor || Comet)"
+            "value": "(AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage || Net7OrLater || Razor || Mvu)"
         },
         "HostIdentifier": {
             "type": "bind",

--- a/src/MauiTemplatesCLI/MauiAppX/App.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/App.xaml
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <Application
-        x:Class="MauiApp._1.App"
-        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-        xmlns:local="clr-namespace:MauiApp._1">
+    x:Class="MauiApp._1.App"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -19,11 +22,13 @@
             <x:Double x:Key="ItemSpacing">10</x:Double>
 
             <Style ApplyToDerivedTypes="True" TargetType="StackBase">
-                <Setter Property="Spacing" Value="{StaticResource ItemSpacing}" />
+                <Setter Property="Spacing" 
+                        Value="{StaticResource ItemSpacing}" />
             </Style>
 
             <Style x:Key="MauiLabel" TargetType="Label">
-                <Setter Property="TextColor" Value="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Primary}}" />
+                <Setter Property="TextColor" 
+                        Value="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Primary}}" />
             </Style>
 
             <Style x:Key="Action" TargetType="Button">

--- a/src/MauiTemplatesCLI/MauiAppX/AppShell.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/AppShell.xaml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<Shell x:Class="MauiApp._1.AppShell"
-       xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-       xmlns:local="clr-namespace:MauiApp._1"
-       xmlns:vw="clr-namespace:MauiApp._1.Views">
+<Shell
+    x:Class="MauiApp._1.AppShell"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vw="clr-namespace:MauiApp._1.Views"
+    mc:Ignorable="d">
     <!--
         The overall app visual hierarchy is defined here, along with navigation.
         Ensure atleast a Flyout item or a TabBar is defined for Shell to work
@@ -22,13 +26,19 @@
         And ensure appropriate page definitions are available for it work as expected
     -->
     <FlyoutItem Title="Calendar">
-        <ShellContent ContentTemplate="{DataTemplate vw:EventsPage}" Route="home" />
+        <ShellContent
+            ContentTemplate="{DataTemplate vw:EventsPage}"
+            Route="home" />
     </FlyoutItem>
     <FlyoutItem Title="Search">
-        <ShellContent ContentTemplate="{DataTemplate vw:SearchPage}" Route="search" />
+        <ShellContent
+            ContentTemplate="{DataTemplate vw:SearchPage}"
+            Route="search" />
     </FlyoutItem>
     <FlyoutItem Title="Settings">
-        <ShellContent ContentTemplate="{DataTemplate vw:SettingsPage}" Route="settings" />
+        <ShellContent
+            ContentTemplate="{DataTemplate vw:SettingsPage}"
+            Route="settings" />
     </FlyoutItem>
     <!--
         When the Flyout is visible this will be a menu item you can tie a click behavior to
@@ -37,7 +47,9 @@
         Uncomment the below section to enable Menu item(s)
         And ensure appropriate page definitions are available for it work as expected
     -->
-    <MenuItem Clicked="OnMenuItemClicked" Text="Logout" />
+    <MenuItem
+        Clicked="OnMenuItemClicked"
+        Text="Logout" />
     <!--
         TabBar lets you define content that won't show up in a Flyout menu. When this content is active
         the flyout menu won't be available. This is useful for creating areas of the application where
@@ -50,7 +62,9 @@
         And ensure appropriate page definitions are available for it work as expected
     -->
     <TabBar>
-        <ShellContent ContentTemplate="{DataTemplate vw:LoginPage}" Route="login" />
+        <ShellContent
+            ContentTemplate="{DataTemplate vw:LoginPage}"
+            Route="login" />
     </TabBar>
     <!-- Optional Templates
     // These may be provided inline as below or as separate classes.

--- a/src/MauiTemplatesCLI/MauiAppX/Helpers/ResourceHelper.markup.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Helpers/ResourceHelper.markup.cs
@@ -1,4 +1,8 @@
-﻿namespace MauiApp._1.Helpers
+﻿#if Mvu
+using Microsoft.Maui.Controls;
+
+#endif
+namespace MauiApp._1.Helpers
 {
     public static class ResourceHelper
     {

--- a/src/MauiTemplatesCLI/MauiAppX/Helpers/VisualStateHelper.markup.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Helpers/VisualStateHelper.markup.cs
@@ -1,3 +1,7 @@
+﻿#if Mvu
+using Microsoft.Maui.Controls;
+
+#endif
 namespace MauiApp._1.Helpers
 {
     public static class VisualStateHelper

--- a/src/MauiTemplatesCLI/MauiAppX/Imports.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Imports.cs
@@ -29,6 +29,9 @@ global using Comet;
 
 // Reactor
 global using MauiReactor;
+#if AddMapsPackage
+global using MauiReactor.Maps;
+#endif
 
 #endif
 #if AddToolkitPackage

--- a/src/MauiTemplatesCLI/MauiAppX/Imports.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Imports.cs
@@ -1,5 +1,9 @@
-#if Comet
+#if Mvu
 global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;
+global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 
 #endif
@@ -7,15 +11,24 @@ global using Microsoft.Extensions.DependencyInjection;
 global using BlazorBindings.Maui;
 
 #endif
-#if Comet
+#if Mvu
 // .NET MAUI
 global using Microsoft.Maui;
 global using Microsoft.Maui.Accessibility;
 global using Microsoft.Maui.Graphics;
 global using Microsoft.Maui.Hosting;
+global using MC = Microsoft.Maui.Controls;
+#endif
+#if Comet
 
 // Comet
 global using Comet;
+
+#endif
+#if Reactor
+
+// Reactor
+global using MauiReactor;
 
 #endif
 #if AddToolkitPackage
@@ -32,7 +45,7 @@ global using CommunityToolkit.Mvvm.Input;
 #if (Hierarchical || Tabbed || Shell)
 global using MauiApp._1.Controls;
 #endif
-#if (Mvvm && !(Razor || Comet))
+#if (Mvvm && !(Razor || Mvu))
 #if (Hierarchical || Tabbed || Shell)
 #if (!Shell)
 global using MauiApp._1.Exceptions;
@@ -61,5 +74,8 @@ global using static Microsoft.Maui.Graphics.Colors;
 #if Comet
 global using static Microsoft.Maui.TextAlignment;
 global using static MauiApp._1.App;
+#endif
+#if Reactor
+global using static MauiApp._1.Helpers.ResourceHelper;
 #endif
 #endif

--- a/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (Hybrid || Razor)-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 <!--#else-->
@@ -99,7 +100,7 @@
 
         <!-- Project Options -->
         <Nullable>enable</Nullable>
-        <!--#if (!Comet)-->
+        <!--#if (!Mvu)-->
         <ImplicitUsings>enable</ImplicitUsings>
         <!--#endif-->
         <RootNamespace>MauiApp._1</RootNamespace>
@@ -168,7 +169,7 @@
         <!--#endif-->
         <!--#if (Net7OrLater)-->
         <!--#if (Net8)-->
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-preview.1.23110.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0-preview.2.*" />
         <!--#else-->
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
         <!--#endif-->
@@ -191,6 +192,10 @@
         <!--#endif-->
         <!--#if (AddMvvmToolkitPackage || (Mvvm && !Razor))-->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0"/>
+        <!--#endif-->
+        <!--#if (Reactor)-->
+        <PackageReference Include="Reactor.Maui" Version="1.0.108" />
+        <PackageReference Include="Reactor.Maui.Canvas" Version="1.0.108" />
         <!--#endif-->
     <!--#if (PackageRef)-->
     </ItemGroup>

--- a/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
@@ -194,8 +194,11 @@
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0"/>
         <!--#endif-->
         <!--#if (Reactor)-->
-        <PackageReference Include="Reactor.Maui" Version="1.0.108" />
-        <PackageReference Include="Reactor.Maui.Canvas" Version="1.0.108" />
+        <PackageReference Include="Reactor.Maui" Version="1.0.113" />
+        <PackageReference Include="Reactor.Maui.Canvas" Version="1.0.113" />
+        <!--#if (AddMapsPackage)-->
+        <PackageReference Include="Reactor.Maui.Maps" Version="1.0.113" />
+        <!--#endif-->
         <!--#endif-->
     <!--#if (PackageRef)-->
     </ItemGroup>

--- a/src/MauiTemplatesCLI/MauiAppX/MauiProgram.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiProgram.cs
@@ -25,6 +25,20 @@ namespace MauiApp._1
             var builder = MauiApp.CreateBuilder();
 #if Comet
             builder.UseCometApp<App>()
+#elif Reactor
+            builder.UseMauiReactorApp<MainPage>(app =>
+                   {
+                       app.AddResource("Resources/Colors.xaml");
+                       app.AddResource("Resources/Styles.xaml");
+                       app.AddResource("Resources/AppStyles.xaml");
+
+                       app.SetWindowsSpecificAssectDirectory("Assets");
+                   })
+//-:cnd:noEmit
+#if DEBUG
+                   .EnableMauiReactorHotReload()
+#endif
+//+:cnd:noEmit
 #else
             builder.UseMauiApp<App>()
 #endif
@@ -56,12 +70,16 @@ namespace MauiApp._1
                        fonts.AddFont("OpenSans-SemiBold.ttf", "OpenSansSemiBold");
                    });
 
-#if (Comet)
+#if Comet
             builder.Services.AddSingleton(SemanticScreenReader.Default);
             builder.Services.AddSingleton<MainPage>();
 
 #endif
-#if (Mvvm && !(Razor || Comet))
+#if Reactor
+            builder.Services.AddSingleton(SemanticScreenReader.Default);
+
+#endif
+#if (Mvvm && !(Razor || Mvu))
 #if Hybrid
             builder.Services.AddSingleton<MainViewModel>();
             builder.Services.AddSingleton<MainPage>();

--- a/src/MauiTemplatesCLI/MauiAppX/Resources/AppStyles.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Resources/AppStyles.xaml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
+        <!-- Additional Styles -->
+        <!--#if (!(Plain || Hybrid))-->
+        <Thickness x:Key="ApplePadding">30,60,30,30</Thickness>
+        <Thickness x:Key="DefaultPadding">30</Thickness>
+        <!--#endif-->
+
+        <x:Double x:Key="ItemSpacing">10</x:Double>
+
+        <Style ApplyToDerivedTypes="True" TargetType="StackBase">
+            <Setter Property="Spacing"
+                    Value="{StaticResource ItemSpacing}" />
+        </Style>
+
+        <Style x:Key="MauiLabel" TargetType="Label">
+            <Setter Property="TextColor"
+                    Value="{AppThemeBinding Dark={StaticResource White}, Light={StaticResource Primary}}" />
+        </Style>
+
+        <Style x:Key="Action" TargetType="Button">
+            <Setter Property="BackgroundColor"
+                    Value="{AppThemeBinding Dark={StaticResource BackgroundDark}, Light={StaticResource BackgroundLight}}" />
+            <Setter Property="TextColor"
+                    Value="{AppThemeBinding Dark={StaticResource TextDark}, Light={StaticResource TextLight}}" />
+            <Setter Property="FontFamily"
+                    Value="{StaticResource AppFont}" />
+            <Setter Property="FontSize"
+                    Value="{StaticResource AppFontSize}" />
+            <Setter Property="Padding"
+                    Value="14,10" />
+        </Style>
+
+        <Style x:Key="PrimaryAction"
+                TargetType="Button"
+                BasedOn="{StaticResource Action}">
+            <Setter Property="BackgroundColor"
+                    Value="{StaticResource Primary}" />
+            <Setter Property="FontAttributes"
+                    Value="Bold" />
+            <Setter Property="TextColor"
+                    Value="{StaticResource White}" />
+        </Style>
+</ResourceDictionary>

--- a/src/MauiTemplatesCLI/MauiAppX/Resources/Colors.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Resources/Colors.xaml
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <?xaml-comp compile="true" ?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
-                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
 
     <Color x:Key="Primary">#512BD4</Color>
     <Color x:Key="Secondary">#DFD8F7</Color>

--- a/src/MauiTemplatesCLI/MauiAppX/Resources/Styles.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Resources/Styles.xaml
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <?xaml-comp compile="true" ?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui" 
-                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
 
     <!-- Update the FontFamily to set it across all Controls styles -->
     <x:String x:Key="AppFont">OpenSansRegular</x:String>

--- a/src/MauiTemplatesCLI/MauiAppX/Views/EventsPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/EventsPage.xaml
@@ -4,17 +4,22 @@
     x:Class="MauiApp._1.Views.EventsPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-    x:DataType="vm:EventsViewModel">
+    x:DataType="vm:EventsViewModel"
+    mc:Ignorable="d">
     <ContentPage.Content>
-        <StackLayout HorizontalOptions="Center"
-                     VerticalOptions="Center">
+        <StackLayout
+            HorizontalOptions="Center"
+            VerticalOptions="Center">
             <Label Text="You don't have anything scheduled today." />
-            <Button Command="{Binding AddEventCommand}"
-                    HorizontalOptions="Center"
-                    Style="{StaticResource PrimaryAction}"
-                    Text="Add Event" />
+            <Button
+                Command="{Binding AddEventCommand}"
+                HorizontalOptions="Center"
+                Style="{StaticResource PrimaryAction}"
+                Text="Add Event" />
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>
@@ -23,15 +28,20 @@
     x:Class="MauiApp._1.Views.EventsPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MauiApp._1">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
     <ContentPage.Content>
-        <StackLayout HorizontalOptions="Center"
-                     VerticalOptions="Center">
+        <StackLayout
+            HorizontalOptions="Center"
+            VerticalOptions="Center">
             <Label Text="You don't have anything scheduled today." />
-            <Button Clicked="OnAddEvent"
-                    HorizontalOptions="Center"
-                    Style="{StaticResource PrimaryAction}"
-                    Text="Add Event" />
+            <Button
+                Clicked="OnAddEvent"
+                HorizontalOptions="Center"
+                Style="{StaticResource PrimaryAction}"
+                Text="Add Event" />
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/src/MauiTemplatesCLI/MauiAppX/Views/LoginPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/LoginPage.xaml
@@ -4,29 +4,44 @@
     x:Class="MauiApp._1.Views.LoginPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
     Shell.NavBarIsVisible="False"
-    x:DataType="vm:LoginViewModel">
-    <StackLayout HorizontalOptions="Center"
-                 VerticalOptions="Center">
-        <Button Command="{Binding LoginCommand}"
+    x:DataType="vm:LoginViewModel"
+    mc:Ignorable="d">
+    <ContentPage.Content>
+        <StackLayout
+            HorizontalOptions="Center"
+            VerticalOptions="Center">
+            <Button
+                Command="{Binding LoginCommand}"
                 Style="{StaticResource PrimaryAction}"
                 Text="Login" />
-    </StackLayout>
+        </StackLayout>
+    </ContentPage.Content>
 </ContentPage>
 <!--#else-->
 <ContentPage
     x:Class="MauiApp._1.Views.LoginPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
-    Shell.NavBarIsVisible="False">
-    <StackLayout HorizontalOptions="Center"
-                 VerticalOptions="Center">
-        <Button Style="{StaticResource PrimaryAction}"
-                Text="Login"
-                Clicked="OnLoginClicked" />
-    </StackLayout>
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Shell.NavBarIsVisible="False"
+    mc:Ignorable="d">
+    <ContentPage.Content>
+        <StackLayout
+            HorizontalOptions="Center"
+            VerticalOptions="Center">
+            <Button
+                Clicked="OnLoginClicked"
+                Style="{StaticResource PrimaryAction}"
+                Text="Login" />
+        </StackLayout>
+    </ContentPage.Content>
 </ContentPage>
 <!--#endif-->

--- a/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.markup.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.markup.cs
@@ -44,6 +44,54 @@
         }
     }
 #endif
+#if Reactor
+    class MainPageState
+    {
+        public string CountText { get; set; } = "Current count: 0";
+    }
+
+    class MainPage : Component<MainPageState>
+    {
+        int count = 0;
+
+        public override VisualNode Render() => new ContentPage()
+        {
+            new VerticalStackLayout()
+            {
+                new Label("Hello, World!").HCenter()
+                                          .Style(AppStyle("MauiLabel"))
+                                          .FontSize(32)
+                                          .Set(MC.SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1),
+                new Label("Welcome to .NET Multi-platform App UI").HCenter()
+                                                                  .Style(AppStyle("MauiLabel"))
+                                                                  .FontSize(18)
+                                                                  .Set(MC.SemanticProperties.DescriptionProperty, "Welcome to dot net Multi platform App U I")
+                                                                  .Set(MC.SemanticProperties.HeadingLevelProperty, SemanticHeadingLevel.Level1),
+                new Label(State.CountText).HCenter()
+                                          .Style(AppStyle("MauiLabel"))
+                                          .FontAttributes(MC.FontAttributes.Bold)
+                                          .FontSize(18),
+                new Button("Click me").HCenter()
+                                      .Style(AppStyle("PrimaryAction"))
+                                      .OnClicked(IncrementCount)
+                                      .Set(MC.SemanticProperties.HintProperty, "Counts the number of times you click"),
+                new Image("dotnet_bot.png").WidthRequest(310)
+                                           .HeightRequest(250)
+                                           .HCenter()
+                                           .Set(MC.SemanticProperties.DescriptionProperty, "Cute dot net bot waving hi to you!")
+            }.VCenter()
+             .Padding(30)
+             .Spacing(25)
+        };
+
+        private void IncrementCount()
+        {
+            count++;
+            SetState(s => s.CountText = $"Current count: {count}");
+            Services.GetService<ISemanticScreenReader>()?.Announce(State.CountText);
+        }
+    }
+#endif
 #if Markup
     public partial class MainPage : ContentPage
     {

--- a/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml
@@ -5,31 +5,41 @@
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
     Title="{Binding Title}"
-    x:DataType="vm:MainViewModel">
-
-    <BlazorWebView HostPage="wwwroot/index.html">
-        <BlazorWebView.RootComponents>
-            <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
-        </BlazorWebView.RootComponents>
-    </BlazorWebView>
-
+    x:DataType="vm:MainViewModel"
+    mc:Ignorable="d">
+    <ContentPage.Content>
+        <BlazorWebView HostPage="wwwroot/index.html">
+            <BlazorWebView.RootComponents>
+                <RootComponent
+                    Selector="#app"
+                    ComponentType="{x:Type local:Main}" />
+            </BlazorWebView.RootComponents>
+        </BlazorWebView>
+    </ContentPage.Content>
 </ContentPage>
 <!--#else-->
 <ContentPage
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MauiApp._1">
-
-    <BlazorWebView HostPage="wwwroot/index.html">
-        <BlazorWebView.RootComponents>
-            <RootComponent Selector="#app" ComponentType="{x:Type local:Main}" />
-        </BlazorWebView.RootComponents>
-    </BlazorWebView>
-
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
+    <ContentPage.Content>
+        <BlazorWebView HostPage="wwwroot/index.html">
+            <BlazorWebView.RootComponents>
+                <RootComponent
+                    Selector="#app"
+                    ComponentType="{x:Type local:Main}" />
+            </BlazorWebView.RootComponents>
+        </BlazorWebView>
+    </ContentPage.Content>
 </ContentPage>
 <!--#endif-->
 <!--#elif (Tabbed)-->
@@ -37,12 +47,16 @@
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:android="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific;assembly=Microsoft.Maui.Controls"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vw="clr-namespace:MauiApp._1.Views"
-    android:TabbedPage.ToolbarPlacement="Bottom">
-    <NavigationPage x:Name="calendar"
-                    Title="Calendar">
+    android:TabbedPage.ToolbarPlacement="Bottom"
+    mc:Ignorable="d">
+    <NavigationPage
+        x:Name="calendar"
+        Title="Calendar">
         <x:Arguments>
             <vw:EventsPage />
         </x:Arguments>
@@ -56,13 +70,17 @@
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
     Title="{Binding Title}"
-    x:DataType="vm:MainViewModel">
+    x:DataType="vm:MainViewModel"
+    mc:Ignorable="d">
     <ContentPage.Content>
-        <StackLayout HorizontalOptions="Center"
-                     VerticalOptions="Center">
+        <StackLayout
+            HorizontalOptions="Center"
+            VerticalOptions="Center">
             <Label Text="You don't have anything scheduled today." />
             <Button Command="{Binding AddEventCommand}"
                     HorizontalOptions="Center"
@@ -76,11 +94,15 @@
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d"
     Title="Calendar">
     <ContentPage.Content>
-        <StackLayout HorizontalOptions="Center"
-                     VerticalOptions="Center">
+        <StackLayout
+            HorizontalOptions="Center"
+            VerticalOptions="Center">
             <Label Text="You don't have anything scheduled today." />
             <Button Style="{StaticResource PrimaryAction}"
                     Text="Add Event"
@@ -96,77 +118,84 @@
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
     Title="{Binding Title}"
-    x:DataType="vm:MainViewModel">
+    x:DataType="vm:MainViewModel"
+    mc:Ignorable="d">
 <!--#else-->
 <ContentPage
     x:Class="MauiApp._1.Views.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MauiApp._1">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
+    mc:Ignorable="d">
 <!--#endif-->
+    <ContentPage.Content>
+        <ScrollView>
+            <StackLayout Padding="30" Spacing="25">
 
-    <ScrollView>
-        <StackLayout Padding="30" Spacing="25">
+                <Label
+                    FontSize="32"
+                    HorizontalOptions="Center"
+                    SemanticProperties.HeadingLevel="Level1"
+                    Style="{StaticResource MauiLabel}"
+                    Text="Hello, World!" />
 
-            <Label
-                FontSize="32"
-                HorizontalOptions="Center"
-                SemanticProperties.HeadingLevel="Level1"
-                Style="{StaticResource MauiLabel}"
-                Text="Hello, World!" />
-
-            <Label
-                FontSize="18"
-                HorizontalOptions="Center"
-                SemanticProperties.Description="Welcome to dot net Multi platform App U I"
-                SemanticProperties.HeadingLevel="Level1"
-                Style="{StaticResource MauiLabel}"
-                Text="Welcome to .NET Multi-platform App UI" />
+                <Label
+                    FontSize="18"
+                    HorizontalOptions="Center"
+                    SemanticProperties.Description="Welcome to dot net Multi platform App U I"
+                    SemanticProperties.HeadingLevel="Level1"
+                    Style="{StaticResource MauiLabel}"
+                    Text="Welcome to .NET Multi-platform App UI" />
 
 <!--#if (Mvvm)-->
-            <Label
-                x:Name="CounterLabel"
-                FontAttributes="Bold"
-                FontSize="18"
-                HorizontalOptions="Center"
-                Style="{StaticResource MauiLabel}"
-                Text="{Binding CountText}" />
+                <Label
+                    x:Name="CounterLabel"
+                    FontAttributes="Bold"
+                    FontSize="18"
+                    HorizontalOptions="Center"
+                    Style="{StaticResource MauiLabel}"
+                    Text="{Binding CountText}" />
 
-            <Button
-                Command="{Binding IncrementCommand}"
-                HorizontalOptions="Center"
-                SemanticProperties.Hint="Counts the number of times you click"
-                Style="{StaticResource PrimaryAction}"
-                Text="Click me" />
+                <Button
+                    Command="{Binding IncrementCommand}"
+                    HorizontalOptions="Center"
+                    SemanticProperties.Hint="Counts the number of times you click"
+                    Style="{StaticResource PrimaryAction}"
+                    Text="Click me" />
 
 <!--#else-->
-            <Label
-                x:Name="CounterLabel"
-                FontAttributes="Bold"
-                FontSize="18"
-                HorizontalOptions="Center"
-                Style="{StaticResource MauiLabel}"
-                Text="Current count: 0" />
+                <Label
+                    x:Name="CounterLabel"
+                    FontAttributes="Bold"
+                    FontSize="18"
+                    HorizontalOptions="Center"
+                    Style="{StaticResource MauiLabel}"
+                    Text="Current count: 0" />
 
-            <Button
-                Clicked="OnCounterClicked"
-                HorizontalOptions="Center"
-                SemanticProperties.Hint="Counts the number of times you click"
-                Style="{StaticResource PrimaryAction}"
-                Text="Click me" />
+                <Button
+                    Clicked="OnCounterClicked"
+                    HorizontalOptions="Center"
+                    SemanticProperties.Hint="Counts the number of times you click"
+                    Style="{StaticResource PrimaryAction}"
+                    Text="Click me" />
 
 <!--#endif-->
-            <Image
-                HeightRequest="310"
-                HorizontalOptions="Center"
-                SemanticProperties.Description="Cute dot net bot waving hi to you!"
-                Source="dotnet_bot.png"
-                WidthRequest="250" />
+                <Image
+                    HeightRequest="310"
+                    HorizontalOptions="Center"
+                    SemanticProperties.Description="Cute dot net bot waving hi to you!"
+                    Source="dotnet_bot.png"
+                    WidthRequest="250" />
 
-        </StackLayout>
-    </ScrollView>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
 </ContentPage>
 <!--#endif-->

--- a/src/MauiTemplatesCLI/MauiAppX/Views/NewEventPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/NewEventPage.xaml
@@ -4,6 +4,8 @@
     x:Class="MauiApp._1.Views.NewEventPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctrl="clr-namespace:MauiApp._1.Controls"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -12,34 +14,42 @@
                          Default={StaticResource DefaultPadding}}"
     Shell.PresentationMode="ModalAnimated"
     Title="{Binding Title}"
-    x:DataType="vm:NewEventViewModel">
+    x:DataType="vm:NewEventViewModel"
+    mc:Ignorable="d">
     <ContentPage.Content>
         <StackLayout>
-            <Entry Text="{Binding Event.Name}"
-                   Placeholder="Event name"
-                   MaxLength="100" />
-            <Entry Text="{Binding Event.Location}"
-                   Placeholder="Location"
-                   MaxLength="100" />
-            <ctrl:DateTimePicker Title="Start:"
-                                  Date="{Binding Event.StartsAt.Date}"
-                                  MinimumDate="{x:Static sys:DateTime.Now}"
-                                  Time="{Binding Event.StartsAt.TimeOfDay}" />
-            <ctrl:DateTimePicker Title="End:"
-                                  Date="{Binding Event.EndsAt.Date}"
-                                  MinimumDate="{x:Static sys:DateTime.Now}"
-                                  Time="{Binding Event.EndsAt.TimeOfDay}" />
-            <Editor Text="{Binding Event.Notes}"
-                    HeightRequest="100"
-                    Placeholder="Notes"
-                    MaxLength="500" />
+            <Entry
+                Text="{Binding Event.Name}"
+                Placeholder="Event name"
+                MaxLength="100" />
+            <Entry
+                Text="{Binding Event.Location}"
+                Placeholder="Location"
+                MaxLength="100" />
+            <ctrl:DateTimePicker
+                Title="Start:"
+                Date="{Binding Event.StartsAt.Date}"
+                MinimumDate="{x:Static sys:DateTime.Now}"
+                Time="{Binding Event.StartsAt.TimeOfDay}" />
+            <ctrl:DateTimePicker
+                Title="End:"
+                Date="{Binding Event.EndsAt.Date}"
+                MinimumDate="{x:Static sys:DateTime.Now}"
+                Time="{Binding Event.EndsAt.TimeOfDay}" />
+            <Editor
+                Text="{Binding Event.Notes}"
+                HeightRequest="100"
+                Placeholder="Notes"
+                MaxLength="500" />
             <HorizontalStackLayout HorizontalOptions="Center">
-                <Button Command="{Binding SaveCommand}"
-                        Style="{StaticResource PrimaryAction}"
-                        Text="Save" />
-                <Button Command="{Binding CancelCommand}"
-                        Style="{StaticResource Action}"
-                        Text="Cancel" />
+                <Button
+                    Command="{Binding SaveCommand}"
+                    Style="{StaticResource PrimaryAction}"
+                    Text="Save" />
+                <Button
+                    Command="{Binding CancelCommand}"
+                    Style="{StaticResource Action}"
+                    Text="Cancel" />
             </HorizontalStackLayout>
         </StackLayout>
     </ContentPage.Content>
@@ -49,6 +59,8 @@
     x:Class="MauiApp._1.Views.NewEventPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ctrl="clr-namespace:MauiApp._1.Controls"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -56,32 +68,40 @@
     Padding="{OnPlatform iOS={StaticResource ApplePadding},
                          Default={StaticResource DefaultPadding}}"
     Shell.PresentationMode="ModalAnimated"
-    Title="New Event">
+    Title="New Event"
+    mc:Ignorable="d">
     <ContentPage.Content>
         <StackLayout>
-            <Entry Text=""
-                   Placeholder="Event name"
-                   MaxLength="100" />
-            <Entry Text=""
-                   Placeholder="Location"
-                   MaxLength="100" />
-            <ctrl:DateTimePicker x:Name="start"
-                                  MinimumDate="{x:Static sys:DateTime.Now}"
-                                  Title="Start:" />
-            <ctrl:DateTimePicker x:Name="end"
-                                  MinimumDate="{x:Static sys:DateTime.Now}"
-                                  Title="End:" />
-            <Editor Text=""
-                    HeightRequest="100"
-                    Placeholder="Notes"
-                    MaxLength="500" />
+            <Entry
+                Text=""
+                Placeholder="Event name"
+                MaxLength="100" />
+            <Entry
+                Text=""
+                Placeholder="Location"
+                MaxLength="100" />
+            <ctrl:DateTimePicker
+                x:Name="start"
+                MinimumDate="{x:Static sys:DateTime.Now}"
+                Title="Start:" />
+            <ctrl:DateTimePicker
+                x:Name="end"
+                MinimumDate="{x:Static sys:DateTime.Now}"
+                Title="End:" />
+            <Editor
+                Text=""
+                HeightRequest="100"
+                Placeholder="Notes"
+                MaxLength="500" />
             <HorizontalStackLayout HorizontalOptions="Center">
-                <Button Style="{StaticResource PrimaryAction}"
-                        Text="Save"
-                        Clicked="OnSave" />
-                <Button Style="{StaticResource Action}"
-                        Text="Cancel"
-                        Clicked="OnCancel" />
+                <Button
+                    Clicked="OnSave"
+                    Style="{StaticResource PrimaryAction}"
+                    Text="Save" />
+                <Button
+                    Clicked="OnCancel"
+                    Style="{StaticResource Action}"
+                    Text="Cancel" />
             </HorizontalStackLayout>
         </StackLayout>
     </ContentPage.Content>

--- a/src/MauiTemplatesCLI/MauiAppX/Views/SearchPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/SearchPage.xaml
@@ -4,20 +4,28 @@
     x:Class="MauiApp._1.Views.SearchPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
     Title="{Binding Title}"
-    x:DataType="vm:SearchViewModel">
+    x:DataType="vm:SearchViewModel"
+    mc:Ignorable="d">
 <!--#else-->
 <ContentPage
     x:Class="MauiApp._1.Views.SearchPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
-    Title="Search">
+    Title="Search"
+    mc:Ignorable="d">
 <!--#endif-->
-    <Label
-        HorizontalOptions="Center"
-        Text="Search"
-        VerticalOptions="Center" />
+    <ContentPage.Content>
+        <Label
+            HorizontalOptions="Center"
+            Text="Search"
+            VerticalOptions="Center" />
+    </ContentPage.Content>
 </ContentPage>

--- a/src/MauiTemplatesCLI/MauiAppX/Views/SettingsPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/SettingsPage.xaml
@@ -4,20 +4,28 @@
     x:Class="MauiApp._1.Views.SettingsPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
     xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
     Title="{Binding Title}"
-    x:DataType="vm:SettingsViewModel">
+    x:DataType="vm:SettingsViewModel"
+    mc:Ignorable="d">
 <!--#else-->
 <ContentPage
     x:Class="MauiApp._1.Views.SettingsPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
-    Title="Settings">
+    Title="Settings"
+    mc:Ignorable="d">
 <!--#endif-->
-    <Label
-        HorizontalOptions="Center"
-        Text="Settings"
-        VerticalOptions="Center" />
+    <ContentPage.Content>
+        <Label
+            HorizontalOptions="Center"
+            Text="Settings"
+            VerticalOptions="Center" />
+    </ContentPage.Content>
 </ContentPage>

--- a/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
+++ b/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--#if (UseRazorSdk)-->
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 <!--#else-->

--- a/src/MauiTemplatesCLI/MauiPage/MauiPage.1.xaml
+++ b/src/MauiTemplatesCLI/MauiPage/MauiPage.1.xaml
@@ -3,7 +3,10 @@
     x:Class="MyApp.Namespace.MauiPage__1"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MyApp.Namespace">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    mc:Ignorable="d">
     <ContentPage.Content>
         <Grid>
             <Label

--- a/src/MauiTemplatesCLI/MauiResDict/MauiResDict.1.xaml
+++ b/src/MauiTemplatesCLI/MauiResDict/MauiResDict.1.xaml
@@ -4,7 +4,10 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MyApp.Namespace">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    mc:Ignorable="d">
     <!-- Define your resources here -->
 </ResourceDictionary>
 <!--#else-->
@@ -12,7 +15,10 @@
     x:Class="MyApp.Namespace.MauiResDict__1"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MyApp.Namespace">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    mc:Ignorable="d">
     <!-- Define your resources here -->
 </ResourceDictionary>
 <!--#endif-->

--- a/src/MauiTemplatesCLI/MauiShell/MauiShell.1.xaml
+++ b/src/MauiTemplatesCLI/MauiShell/MauiShell.1.xaml
@@ -3,7 +3,10 @@
     x:Class="MyApp.Namespace.MauiShell__1"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MyApp.Namespace">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    mc:Ignorable="d">
     <!--
         The overall app visual hierarchy is defined here, along with navigation.
         Ensure atleast a Flyout item or a TabBar is defined for Shell to work
@@ -25,10 +28,14 @@
     <!--#endif-->
     <!--
     <FlyoutItem Title="Home">
-        <ShellContent ContentTemplate="{DataTemplate local:HomePage}" Route="home" />
+        <ShellContent
+            ContentTemplate="{DataTemplate local:HomePage}"
+            Route="home" />
     </FlyoutItem>
     <FlyoutItem Title="Search">
-        <ShellContent ContentTemplate="{DataTemplate local:SearchPage}" Route="search" />
+        <ShellContent
+            ContentTemplate="{DataTemplate local:SearchPage}"
+            Route="search" />
     </FlyoutItem>
     -->
     <!--
@@ -41,7 +48,9 @@
     -->
     <!--#endif-->
     <!--
-    <MenuItem Clicked="OnMenuItemClicked" Text="Logout" />
+    <MenuItem
+        Clicked="OnMenuItemClicked"
+        Text="Logout" />
     -->
     <!--
         TabBar lets you define content that won't show up in a Flyout menu. When this content is active
@@ -58,7 +67,9 @@
     <!--#endif-->
     <!--
     <TabBar>
-        <ShellContent ContentTemplate="{DataTemplate local:LoginPage}" Route="login" />
+        <ShellContent
+            ContentTemplate="{DataTemplate local:LoginPage}"
+            Route="login" />
     </TabBar>
     -->
     <!-- Optional Templates

--- a/src/MauiTemplatesCLI/MauiView/MauiView.1.xaml
+++ b/src/MauiTemplatesCLI/MauiView/MauiView.1.xaml
@@ -3,7 +3,10 @@
     x:Class="MyApp.Namespace.MauiView__1"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MyApp.Namespace">
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    mc:Ignorable="d">
     <ContentView.Content>
         <Grid>
             <Label

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.1.0-preview.6
+3.1.0-preview.7

--- a/src/MauiTemplatesCLI/SharedClassLib/SharedClassLib.1.csproj
+++ b/src/MauiTemplatesCLI/SharedClassLib/SharedClassLib.1.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;MAUI_TFM</TargetFrameworks>

--- a/src/MauiTemplatesCLI/overview.md
+++ b/src/MauiTemplatesCLI/overview.md
@@ -165,6 +165,7 @@ Can take any one of the following values, with default value set to `Plain`:
 |Markup|App configured to work with C# Markup syntax.|
 |Razor|App configured to work with Razor syntax.|
 |Comet|App configured to work with MVU pattern using Comet.|
+|Reactor|App configured to work with MVU pattern using Reactor.|
 
 * `-tp` | `--target-platform`
 
@@ -306,6 +307,9 @@ dotnet new mauiapp -n MyApp -dp Razor
 ```shell
 dotnet new mauiapp -n MyApp -dp Comet
 ```
+```shell
+dotnet new mauiapp -n MyApp -dp Reactor
+```
 Option to use MVVM:
 ```shell
 dotnet new mauiapp -n MyApp -mvvm
@@ -407,6 +411,9 @@ dotnet new mauiapp --name MyApp --design-pattern Razor
 ```
 ```shell
 dotnet new mauiapp --name MyApp --design-pattern Comet
+```
+```shell
+dotnet new mauiapp --name MyApp --design-pattern Reactor
 ```
 Option to use MVVM:
 ```shell

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,5 +1,15 @@
-What's new in ver. 3.1.0-preview.6:
+What's new in ver. 3.1.0-preview.7:
 -----------------------------------
+1. Added the option to create a .NET MAUI App with the MVU pattern using Reactor.
+
+To facilitate this, the design-pattern parameter now takes the option of Reactor.
+
+dotnet new mauiapp -o MyApp -dp Reactor
+
+Note: MVVM option won't have any impact on the App created with Reactor option as it is based on the MVU design pattern.
+
+v3.1.0-preview.6:
+
 1. Now MVVM option works with an App created with a Hybrid design pattern also.
 
 dotnet new mauiapp -o MyApp -dp Hybrid -mvvm


### PR DESCRIPTION
* Added the option to create a .NET MAUI App with the **MVU pattern using Reactor**.

To facilitate this, the **design-pattern** parameter now takes the option of **Reactor**.

```shell
dotnet new mauiapp -o MyApp -dp Reactor
```

_Note: The MVVM option won't have any impact on the App created with the Reactor option as it is based on the MVU design pattern._