### PR TITLE
Added Item templates for Page with ViewModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## .NET MAUI Project and Item Templates
+
 This repository is to host the .NET MAUI Project Templates, Item Templates and Code Snippets.
 
 Join me on [**Developer Thoughts**](https://egvijayanand.in/ "Developer Thoughts"), an exclusive blog for .NET MAUI and Blazor, for articles on working with these templates and much more.
@@ -112,20 +113,22 @@ This comes with with the following templates:
 
 Name | Template Name | Type
 :---: | :---: | :---:
-[All-in-One .NET MAUI App](#all-in-one-net-maui-app-project-template) | mauiapp | Project
-[.NET MAUI Class Library](#net-maui-class-library-template) | mauiclasslib | Project
-[Shared Class Library](#shared-class-library-template) | sharedclasslib | Project
-ContentPage (XAML) | maui-page | Item
-ContentPage (C#) | maui-page-cs | Item
-ContentPage (Razor) | maui-page-razor | Item
-ContentView (XAML) | maui-view | Item
-ContentView (C#) | maui-view-cs | Item
-ContentView (Razor) | maui-view-razor | Item
-ResourceDictionary | maui-resdict | Item
-ShellPage (XAML) | maui-shell | Item
-ShellPage (C#) | maui-shell-cs | Item
-ShellPage (Razor) | maui-shell-razor | Item
-[Partial Class (C#)](#partial-class-item-template) | class-cs | Item
+|[All-in-One .NET MAUI App](#all-in-one-net-maui-app-project-template)|mauiapp|Project|
+|[.NET MAUI Class Library](#net-maui-class-library-template)|mauiclasslib|Project|
+|[Shared Class Library](#shared-class-library-template)|sharedclasslib|Project|
+|ContentPage (XAML)|maui-page|Item|
+|ContentPage (C#)|maui-page-cs|Item|
+|ContentPage (Razor)|maui-page-razor|Item|
+|ContentView (XAML)|maui-view|Item|
+|ContentView (C#)|maui-view-cs|Item|
+|ContentView (Razor)|maui-view-razor|Item|
+|ResourceDictionary|maui-resdict|Item|
+|ShellPage (XAML)|maui-shell|Item|
+|ShellPage (C#)|maui-shell-cs|Item|
+|ShellPage (Razor)|maui-shell-razor|Item|
+|[ContentPage (XAML) with ViewModel](#page-with-viewmodel)|maui-mvvm|Item|
+|[ContentPage (C#) with ViewModel](#page-with-viewmodel)|maui-mvvm-cs|Item|
+|[Partial Class (C#)](#partial-class-item-template)|class-cs|Item|
 
 ![All-in-One .NET MAUI App Project Template](images/dotnetmaui-all-in-one-project-template-pinned.png)
 
@@ -460,6 +463,17 @@ dotnet new maui-page-cs -n HomePage -na MyApp.Views
 dotnet new maui-page-razor -n HomePage
 ```
 
+#### Page with ViewModel:
+
+*Don't suffix anything to the name, it'll be included automatically.*
+
+```shell
+dotnet new maui-mvvm -n Login
+```
+```shell
+dotnet new maui-mvvm-cs -n Login
+```
+
 Views:
 ```shell
 dotnet new maui-view -n CardView -na MyApp.Views
@@ -563,6 +577,17 @@ dotnet new maui-page-cs --name HomePage --namespace MyApp.Views
 ```
 ```shell
 dotnet new maui-page-razor --name HomePage
+```
+
+Page with ViewModel:
+
+*Don't suffix anything to the name, it'll be included automatically.*
+
+```shell
+dotnet new maui-mvvm --name Login
+```
+```shell
+dotnet new maui-mvvm-cs --name Login
 ```
 
 Views:

--- a/src/MauiTemplatesCLI/MauiAppX/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiAppX/.template.config/ide.host.json
@@ -29,7 +29,7 @@
         {
             "id": "include-compiled-bindings",
             "name": {
-                "text": "Use Compiled_Bindings.MAUI."
+                "text": "Use Com_piledBindings.MAUI."
             },
             "isVisible": true,
             "defaultValue": "false"
@@ -61,7 +61,7 @@
         {
             "id": "include-maps",
             "name": {
-                "text": "Add and configure Microsoft.Maui._Controls.Maps NuGet package reference (.NET 7 or later)"
+                "text": "Add and configure Microsoft.Maui.Controls.M_aps NuGet package reference (.NET 7 or later)"
             },
             "isVisible": true,
             "defaultValue": "false"

--- a/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiAppX/.template.config/template.json
@@ -352,14 +352,14 @@
             "datatype": "bool",
             "defaultValue": "false",
             "description": "Option to use MVVM.",
-            "displayName": "Option to use MVVM"
+            "displayName": "Option to u_se MVVM"
         },
         "include-compiled-bindings": {
             "type": "parameter",
             "datatype": "bool",
             "defaultValue": "false",
             "description": "Option to add CompiledBindings.MAUI NuGet package reference.",
-            "displayName": "Option to add Compiled_Bindings.MAUI NuGet package reference"
+            "displayName": "Option to add Com_piledBindings.MAUI NuGet package reference"
         },
         "include-toolkit": {
             "type": "parameter",
@@ -387,7 +387,7 @@
             "datatype": "bool",
             "defaultValue": "false",
             "description": "Option to add and configure Microsoft.Maui.Controls.Maps NuGet package reference (.NET 7 or later).",
-            "displayName": "Add and configure Microsoft.Maui._Controls.Maps NuGet package reference"
+            "displayName": "Add and configure Microsoft.Maui.Controls.M_aps NuGet package reference"
         },
         "include-media-element": {
             "type": "parameter",
@@ -414,7 +414,8 @@
             "type": "parameter",
             "datatype": "bool",
             "defaultValue": "false",
-            "description": "Option to configure conditional compilation so that platform source files can be anywhere."
+            "description": "Option to configure conditional compilation so that platform source files can be anywhere.",
+            "displayName": "Option to configure c_onditional compilation so that platform source files can be anywhere"
         },
         "no-solution-file": {
             "type": "parameter",

--- a/src/MauiTemplatesCLI/MauiMvvm/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiMvvm/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "namespace": {
+      "shortName": "na"
+    }
+  }
+}

--- a/src/MauiTemplatesCLI/MauiMvvm/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiMvvm/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiMvvm/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiMvvm/.template.config/template.json
@@ -1,0 +1,82 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "Maui1",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Windows",
+        "MVVM",
+        "Xaml"
+    ],
+    "identity": "VijayAnand.MauiMvvm",
+    "groupIdentity": "VijayAnand.MauiTemplates.Mvvm.Xaml",
+    "description": "An item template for .NET MAUI ContentPage in XAML and its ViewModel",
+    "name": ".NET MAUI ContentPage (XAML) and ViewModel",
+    "shortName": "maui-mvvm",
+    "sourceName": "Maui.1",
+    "primaryOutputs": [
+        {
+            "path": "Maui.1Page.xaml"
+        },
+        {
+            "path": "Maui.1Page.xaml.cs"
+        },
+        {
+            "path": "Maui.1ViewModel.cs"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+    "sources": [
+        {
+            "condition": "(SameFolder)",
+            "include": [
+                "**/*"
+            ]
+        },
+        {
+            "condition": "(!SameFolder)",
+            "rename": {
+                "Maui.1Page.xaml": "Views/Maui.1Page.xaml",
+                "Maui.1Page.xaml.cs": "Views/Maui.1Page.xaml.cs",
+                "Maui.1ViewModel.cs": "ViewModels/Maui.1ViewModel.cs"
+            }
+        }
+    ],
+    "symbols": {
+        "namespace": {
+            "type": "bind",
+            "binding": "msbuild:RootNamespace",
+            "replaces": "MyApp.Namespace",
+            "defaultValue": "MyApp.Namespace"
+        },
+        "same-folder": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "Option to create the artifacts in the same folder.",
+            "displayName": "Option to create the artifacts in the same folder"
+        },
+        "SameFolder": {
+            "type": "computed",
+            "value": "(same-folder)"
+        }
+    },
+    "constraints": {
+        "dotnet7-sts": {
+            "type": "sdk-version",
+            "args": [
+                "[7.0,)"
+            ]
+        },
+        "csharp-only": {
+            "type": "project-capability",
+            "args": "CSharp"
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiMvvm/Maui.1Page.xaml
+++ b/src/MauiTemplatesCLI/MauiMvvm/Maui.1Page.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--#if (SameFolder)-->
+<ContentPage
+    x:Class="MyApp.Namespace.Maui__1Page"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    xmlns:vm="clr-namespace:MyApp.Namespace"
+    x:DataType="vm:Maui__1ViewModel"
+    mc:Ignorable="d">
+<!--#else-->
+<ContentPage
+    x:Class="MyApp.Namespace.Views.Maui__1Page"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    xmlns:vm="clr-namespace:MyApp.Namespace.ViewModels"
+    x:DataType="vm:Maui__1ViewModel"
+    mc:Ignorable="d">
+<!--#endif-->
+    <ContentPage.Content>
+        <Grid>
+            <Label
+                HorizontalOptions="Center"
+                Text="Welcome to .NET MAUI!!!"
+                TextColor="Purple"
+                VerticalOptions="Center" />
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/MauiTemplatesCLI/MauiMvvm/Maui.1Page.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiMvvm/Maui.1Page.xaml.cs
@@ -1,4 +1,8 @@
-﻿#if SameFolder
+﻿#if (!SameFolder)
+using MyApp.Namespace.ViewModels;
+
+#endif
+#if SameFolder
 namespace MyApp.Namespace
 #else
 namespace MyApp.Namespace.Views

--- a/src/MauiTemplatesCLI/MauiMvvm/Maui.1Page.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiMvvm/Maui.1Page.xaml.cs
@@ -1,0 +1,15 @@
+﻿#if SameFolder
+namespace MyApp.Namespace
+#else
+namespace MyApp.Namespace.Views
+#endif
+{
+    public partial class Maui__1Page : ContentPage
+    {
+        public Maui__1Page(Maui__1ViewModel viewModel)
+        {
+            InitializeComponent();
+            BindingContext = viewModel;
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiMvvm/Maui.1ViewModel.cs
+++ b/src/MauiTemplatesCLI/MauiMvvm/Maui.1ViewModel.cs
@@ -1,0 +1,14 @@
+﻿#if SameFolder
+namespace MyApp.Namespace
+#else
+namespace MyApp.Namespace.ViewModels
+#endif
+{
+    public partial class Maui__1ViewModel : BaseViewModel
+    {
+        public Maui__1ViewModel()
+        {
+            
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiMvvmCS/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiMvvmCS/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "namespace": {
+      "shortName": "na"
+    }
+  }
+}

--- a/src/MauiTemplatesCLI/MauiMvvmCS/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiMvvmCS/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiMvvmCS/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiMvvmCS/.template.config/template.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "Maui1",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Windows",
+        "MVVM",
+        "Code"
+    ],
+    "identity": "VijayAnand.MauiMvvmCS",
+    "groupIdentity": "VijayAnand.MauiTemplates.Mvvm.Code",
+    "description": "An item template for .NET MAUI ContentPage in C# and its ViewModel",
+    "name": ".NET MAUI ContentPage (C#) and ViewModel",
+    "shortName": "maui-mvvm-cs",
+    "sourceName": "Maui.1",
+    "primaryOutputs": [
+        {
+            "path": "Maui.1Page.cs"
+        },
+        {
+            "path": "Maui.1ViewModel.cs"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+    "sources": [
+        {
+            "condition": "(SameFolder)",
+            "include": [
+                "**/*"
+            ]
+        },
+        {
+            "condition": "(!SameFolder)",
+            "rename": {
+                "Maui.1Page.cs": "Views/Maui.1Page.cs",
+                "Maui.1ViewModel.cs": "ViewModels/Maui.1ViewModel.cs"
+            }
+        }
+    ],
+    "symbols": {
+        "namespace": {
+            "type": "bind",
+            "binding": "msbuild:RootNamespace",
+            "replaces": "MyApp.Namespace",
+            "defaultValue": "MyApp.Namespace"
+        },
+        "same-folder": {
+            "type": "parameter",
+            "datatype": "bool",
+            "defaultValue": "false",
+            "description": "Option to create the artifacts in the same folder.",
+            "displayName": "Option to create the artifacts in the same folder"
+        },
+        "SameFolder": {
+            "type": "computed",
+            "value": "(same-folder)"
+        }
+    },
+    "constraints": {
+        "dotnet7-sts": {
+            "type": "sdk-version",
+            "args": [
+                "[7.0,)"
+            ]
+        },
+        "csharp-only": {
+            "type": "project-capability",
+            "args": "CSharp"
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiMvvmCS/Maui.1Page.cs
+++ b/src/MauiTemplatesCLI/MauiMvvmCS/Maui.1Page.cs
@@ -1,4 +1,8 @@
-﻿#if SameFolder
+﻿#if (!SameFolder)
+using MyApp.Namespace.ViewModels;
+
+#endif
+#if SameFolder
 namespace MyApp.Namespace
 #else
 namespace MyApp.Namespace.Views

--- a/src/MauiTemplatesCLI/MauiMvvmCS/Maui.1Page.cs
+++ b/src/MauiTemplatesCLI/MauiMvvmCS/Maui.1Page.cs
@@ -1,0 +1,27 @@
+﻿#if SameFolder
+namespace MyApp.Namespace
+#else
+namespace MyApp.Namespace.Views
+#endif
+{
+    public partial class Maui__1Page : ContentPage
+    {
+        public Maui__1Page(Maui__1ViewModel viewModel)
+        {
+            BindingContext = viewModel;
+            Content = new Grid()
+            {
+                Children =
+                {
+                    new Label()
+                    {
+                        Text = "Welcome to .NET MAUI!!!",
+                        TextColor = Colors.Purple,
+                        HorizontalOptions = LayoutOptions.Center,
+                        VerticalOptions = LayoutOptions.Center
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiMvvmCS/Maui.1ViewModel.cs
+++ b/src/MauiTemplatesCLI/MauiMvvmCS/Maui.1ViewModel.cs
@@ -1,0 +1,14 @@
+﻿#if SameFolder
+namespace MyApp.Namespace
+#else
+namespace MyApp.Namespace.ViewModels
+#endif
+{
+    public partial class Maui__1ViewModel : BaseViewModel
+    {
+        public Maui__1ViewModel()
+        {
+            
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.1.0-preview.8
+3.1.0-preview.9

--- a/src/MauiTemplatesCLI/VijayAnand.MauiTemplates.csproj
+++ b/src/MauiTemplatesCLI/VijayAnand.MauiTemplates.csproj
@@ -29,7 +29,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <Content Include="MauiPage\**\*;MauiPageCS\**\*;MauiPageRazor\**\*;MauiView\**\*;MauiViewCS\**\*;MauiViewRazor\**\*;MauiShell\**\*;MauiShellCS\**\*;MauiShellRazor\**\*;MauiClassLib\**\*;MauiAppX\**\*;MauiResDict\**\*;SharedClassLib\**\*;MyClass\**\*"
+        <Content Include="MauiPage\**\*;MauiPageCS\**\*;MauiPageRazor\**\*;MauiView\**\*;MauiViewCS\**\*;MauiViewRazor\**\*;MauiShell\**\*;MauiShellCS\**\*;MauiShellRazor\**\*;MauiClassLib\**\*;MauiAppX\**\*;MauiResDict\**\*;SharedClassLib\**\*;MauiMvvm\**\*;MauiMvvmCS\**\*;MyClass\**\*"
                  Exclude="**\bin\**;**\obj\**"/>
         <Compile Remove="**\*"/>
         <None Include="overview.md" Pack="true" PackagePath="\" />

--- a/src/MauiTemplatesCLI/overview.md
+++ b/src/MauiTemplatesCLI/overview.md
@@ -1,4 +1,4 @@
-### Project and Item Templates for developing .NET MAUI App that runs on iOS, Android, macOS, and Windows 
+### Project and Item Templates for developing .NET MAUI App that runs on Android, iOS, macOS, Windows, and Tizen
 
 * [All-in-One .NET MAUI App](#all-in-one-net-maui-app-project-template) project template and is named as `mauiapp`
 * [.NET MAUI Class Library](#net-maui-class-library-project-template) project template and is named as `mauiclasslib`
@@ -18,6 +18,8 @@ Item templates for the following:
 |ShellPage (XAML)|maui-shell|
 |ShellPage (C#)|maui-shell-cs|
 |ShellPage (Razor)|maui-shell-razor|
+|[ContentPage (XAML) with ViewModel](#page-with-viewmodel)|maui-mvvm|
+|[ContentPage (C#) with ViewModel](#page-with-viewmodel)|maui-mvvm-cs|
 |[Partial Class (C#)](#partial-class-item-template)|class-cs|
 
 All of these templates currently target `.NET MAUI on .NET 6/7 GA and its Service Releases and .NET 8 Previews`.
@@ -364,6 +366,17 @@ dotnet new maui-page-cs -n HomePage -na MyApp.Views
 dotnet new maui-page-razor -n HomePage
 ```
 
+#### Page with ViewModel:
+
+*Don't suffix anything to the name, it'll be included automatically.*
+
+```shell
+dotnet new maui-mvvm -n Login
+```
+```shell
+dotnet new maui-mvvm-cs -n Login
+```
+
 Views:
 ```shell
 dotnet new maui-view -n CardView -na MyApp.Views
@@ -467,6 +480,17 @@ dotnet new maui-page-cs --name HomePage --namespace MyApp.Views
 ```
 ```shell
 dotnet new maui-page-razor --name HomePage
+```
+
+#### Page with ViewModel:
+
+*Don't suffix anything to the name, it'll be included automatically.*
+
+```shell
+dotnet new maui-mvvm --name Login
+```
+```shell
+dotnet new maui-mvvm-cs --name Login
 ```
 
 Views:

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,7 +1,44 @@
 Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for articles on .NET MAUI and Blazor.
 
-What's new in ver. 3.1.0-preview.8:
+What's new in ver. 3.1.0-preview.9:
 -----------------------------------
+1. Introduced an item template to generate Page and its ViewModel in a single command, available for both XAML and C#.
+
+The Page will be generated in the Views folder and ViewModel will be generated in the ViewModels folder.
+
+Can also be overridden to generate in the same folder with the -sf | --same-folder option.
+
+The ViewModels are generated with the base class titled BaseViewModel (implementation left to the user).
+
+Recommended to add CommunityToolkit.Mvvm, an officially supported NuGet package, to make it easy to work with MVVM design pattern.
+
+Since it makes use of the .NET 7 SDK feature of auto namespace resolution, so restore the project before executing the commands.
+
+Note: Don't suffix anything to the name, it'll be included automatically.
+
+dotnet new maui-mvvm -n Login
+
+dotnet new maui-mvvm-cs -n Login
+
+Output structure:
+
+XAML:
+
+ViewModels
+    LoginViewModel.cs
+Views
+    LoginPage.xaml
+    LoginPage.xaml.cs
+
+C#:
+
+ViewModels
+    LoginViewModel.cs
+Views
+    LoginPage.cs
+
+v3.1.0-preview.8:
+
 1. Added the option to use Compiled Bindings option while using the MVVM option. This will make use of the x:Bind extension instead of the Binding extension.
 
 -icb | --include-compiled-bindings - Default value is false.


### PR DESCRIPTION
* Introduced an item template to generate Page and its ViewModel in a single command, available for both XAML and C#.
  - The Page will be generated in the `Views` folder and ViewModel will be generated in the `ViewModels` folder.
  - Can also be overridden to generate in the same folder with the `-sf` | `--same-folder` option.
  - The ViewModels are generated with the base class titled `BaseViewModel` (_implementation left to the user_).
  - Recommended adding [CommunityToolkit.Mvvm](https://www.nuget.org/packages/CommunityToolkit.Mvvm), an officially supported NuGet package, makes it easy to work with the MVVM design pattern.
  - Since it makes use of the .NET 7 SDK feature of auto namespace resolution, so restore the project before executing the commands.

_Note: Don't suffix anything to the name, it'll be included automatically._
```shell
dotnet new maui-mvvm -n Login
```
```shell
dotnet new maui-mvvm-cs -n Login
```
**Output structure:**

**XAML:**

* ViewModels
  - LoginViewModel.cs
* Views
  - LoginPage.xaml
  - LoginPage.xaml.cs

**C#:**

* ViewModels
  - LoginViewModel.cs
* Views
  - LoginPage.cs