### PR TITLE
StartPath property and Menu style change

### DIFF
--- a/src/MauiTemplatesCLI/MauiAppX/Data/WeatherForecast.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/Data/WeatherForecast.cs
@@ -12,6 +12,6 @@ namespace MauiApp._1.Data
 
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
-        public string Summary { get; set; }
+        public string? Summary { get; set; }
     }
 }

--- a/src/MauiTemplatesCLI/MauiAppX/Shared/NavMenu.razor
+++ b/src/MauiTemplatesCLI/MauiAppX/Shared/NavMenu.razor
@@ -30,7 +30,7 @@
 @code {
 	private bool collapseNavMenu = true;
 
-	private string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+	private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
 	private void ToggleNavMenu()
 	{

--- a/src/MauiTemplatesCLI/MauiAppX/Shared/NavMenu.razor.css
+++ b/src/MauiTemplatesCLI/MauiAppX/Shared/NavMenu.razor.css
@@ -57,6 +57,6 @@
 
 	.collapse {
 		/* Never collapse the sidebar for wide screens */
-		display: block;
+		display: block !important;
 	}
 }

--- a/src/MauiTemplatesCLI/MauiAppX/ViewModels/MainViewModel.cs
+++ b/src/MauiTemplatesCLI/MauiAppX/ViewModels/MainViewModel.cs
@@ -7,6 +7,11 @@
         {
             Title = "Home";
         }
+
+#if Net8
+        [ObservableProperty]
+        private string _startPath = "/counter";
+#endif
 #elif (Plain || Markup)
         private int count = 0;
         private readonly ISemanticScreenReader _screenReader;

--- a/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml
+++ b/src/MauiTemplatesCLI/MauiAppX/Views/MainPage.xaml
@@ -13,21 +13,14 @@
     Title="{x:Bind Title}"
     x:DataType="vm:MainViewModel"
     mc:Ignorable="d">
-<!--#else-->
-<ContentPage
-    x:Class="MauiApp._1.Views.MainPage"
-    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:MauiApp._1"
-    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
-    Title="{Binding Title}"
-    x:DataType="vm:MainViewModel"
-    mc:Ignorable="d">
-<!--#endif-->
     <ContentPage.Content>
+<!--#if (Net8)-->
+        <BlazorWebView
+            HostPage="wwwroot/index.html"
+            StartPath="{x:Bind StartPath}">
+<!--#else-->
         <BlazorWebView HostPage="wwwroot/index.html">
+<!--#endif-->
             <BlazorWebView.RootComponents>
                 <RootComponent
                     Selector="#app"
@@ -44,10 +37,45 @@
     xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:MauiApp._1"
+    xmlns:vm="clr-namespace:MauiApp._1.ViewModels"
+    Title="{Binding Title}"
+    x:DataType="vm:MainViewModel"
+    mc:Ignorable="d">
+    <ContentPage.Content>
+<!--#if (Net8)-->
+        <BlazorWebView
+            HostPage="wwwroot/index.html"
+            StartPath="{Binding StartPath}">
+<!--#else-->
+        <BlazorWebView HostPage="wwwroot/index.html">
+<!--#endif-->
+            <BlazorWebView.RootComponents>
+                <RootComponent
+                    Selector="#app"
+                    ComponentType="{x:Type local:Main}" />
+            </BlazorWebView.RootComponents>
+        </BlazorWebView>
+    </ContentPage.Content>
+</ContentPage>
+<!--#endif-->
+<!--#else-->
+<ContentPage
+    x:Class="MauiApp._1.Views.MainPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MauiApp._1"
     Title="MauiApp._1"
     mc:Ignorable="d">
     <ContentPage.Content>
+<!--#if (Net8)-->
+        <BlazorWebView
+            HostPage="wwwroot/index.html"
+            StartPath="/counter">
+<!--#else-->
         <BlazorWebView HostPage="wwwroot/index.html">
+<!--#endif-->
             <BlazorWebView.RootComponents>
                 <RootComponent
                     Selector="#app"

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.2.0-preview.2
+3.2.0-preview.3

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,7 +1,13 @@
 Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for articles on .NET MAUI and Blazor.
 
-What's new in ver. 3.2.0-preview.2:
+What's new in ver. 3.2.0-preview.3:
 -----------------------------------
+1. While targeting .NET 8, the StartPath property is set to load a Razor component other than the one defined with the default route address of '/'
+
+2. A change in the navigation menu style for better interop
+
+v3.2.0-preview.2:
+
 1. Fixed the issue #124 - The project node is not closed properly in the solution file while creating a Blazor Hybrid with the RCL option from CLI.
 
 2. Stability improvements that extend the list of copy-only binary files.


### PR DESCRIPTION
* While targeting .NET 8, the **StartPath** property is set to load a Razor component other than the one defined with the default route address of `/`
* A change in the navigation menu style for better interop