### PR TITLE
Item templates for ContentPage with BlazorWebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Name | Template Name | Type
 |ShellPage (Razor)|maui-shell-razor|Item|
 |[ContentPage with ViewModel](#page-with-viewmodel)|maui-mvvm|Item|
 |[ContentPage with ViewModel (C#)](#page-with-viewmodel)|maui-mvvm-cs|Item|
+|ContentPage with BlazorWebView (XAML)|maui-bwv|Item|
+|ContentPage with BlazorWebView (C#)|maui-bwv-cs|Item|
 |[Partial Class (C#)](#partial-class-item-template)|class-cs|Item|
 
 ![All-in-One .NET MAUI App Project Template](images/dotnetmaui-all-in-one-project-template-pinned.png)
@@ -465,7 +467,7 @@ dotnet new sharedclasslib -n MyApp.UI -asp
 
 Pages:
 ```shell
-dotnet new maui-page -n LoginPage -na MyApp.Views
+dotnet new maui-page -n HomePage -na MyApp.Views
 ```
 ```shell
 dotnet new maui-page-cs -n HomePage -na MyApp.Views
@@ -485,9 +487,18 @@ dotnet new maui-mvvm -n Login
 dotnet new maui-mvvm-cs -n Login
 ```
 
+ContentPage with BlazorWebView:
+
+```shell
+dotnet new maui-bwv -n HomePage -na MyApp.Views
+```
+```shell
+dotnet new maui-bwv-cs -n HomePage -na MyApp.Views
+```
+
 Views:
 ```shell
-dotnet new maui-view -n CardView -na MyApp.Views
+dotnet new maui-view -n OrderView -na MyApp.Views
 ```
 ```shell
 dotnet new maui-view-cs -n OrderView -na MyApp.Views
@@ -585,7 +596,7 @@ dotnet new sharedclasslib --name MyApp.UI --all-supported-packages
 
 Pages:
 ```shell
-dotnet new maui-page --name LoginPage --namespace MyApp.Views
+dotnet new maui-page --name HomePage --namespace MyApp.Views
 ```
 ```shell
 dotnet new maui-page-cs --name HomePage --namespace MyApp.Views
@@ -605,9 +616,18 @@ dotnet new maui-mvvm --name Login
 dotnet new maui-mvvm-cs --name Login
 ```
 
+ContentPage with BlazorWebView:
+
+```shell
+dotnet new maui-bwv --name HomePage --namespace MyApp.Views
+```
+```shell
+dotnet new maui-bwv-cs --name HomePage --namespace MyApp.Views
+```
+
 Views:
 ```shell
-dotnet new maui-view --name CardView --namespace MyApp.Views
+dotnet new maui-view --name OrderView --namespace MyApp.Views
 ```
 ```shell
 dotnet new maui-view-cs --name OrderView --namespace MyApp.Views

--- a/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
+++ b/src/MauiTemplatesCLI/MauiAppX/MauiApp.1.csproj
@@ -113,8 +113,12 @@
         <ApplicationTitle>MauiApp.1</ApplicationTitle>
 
         <!-- App Identifier -->
+        <!--#if (!IsWindows)-->
         <ApplicationId>com.companyname.mauiappid</ApplicationId>
+        <!--#endif-->
+        <!--#if (AllPlatforms || IsWindows)-->
         <ApplicationIdGuid>81a9fb0a-63f5-4ef6-b38e-0cf88600102a</ApplicationIdGuid>
+        <!--#endif-->
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
@@ -217,14 +221,14 @@
     <!--#if (PackageRef)-->
     </ItemGroup>
     <!--#endif-->
-
     <!--#if (Hybrid && RazorLib)-->
+
     <ItemGroup>
         <ProjectReference Include="..\MauiApp.1.RazorLib\MauiApp.1.RazorLib.csproj" />
     </ItemGroup>
     <!--#endif-->
-
     <!--#if (ConditionalCompilation)-->
+
     <ItemGroup Condition="'$(TargetFramework)' != 'MAUI_TFM'">
         <Compile Remove="**\*.Standard.cs" />
         <None Include="**\*.Standard.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

--- a/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "namespace": {
+      "shortName": "na"
+    }
+  }
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/template.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "MauiPage1",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Windows",
+        "Blazor",
+        "Xaml"
+    ],
+    "identity": "VijayAnand.MauiBlazorWebView",
+    "groupIdentity": "VijayAnand.MauiTemplates.BlazorWebView.Xaml",
+    "description": "An item template for .NET MAUI ContentPage with BlazorWebView",
+    "name": ".NET MAUI ContentPage with BlazorWebView",
+    "shortName": "maui-bwv",
+    "sourceName": "MauiBlazorWebView.1",
+    "primaryOutputs": [
+        {
+            "path": "MauiBlazorWebView.1.xaml"
+        },
+        {
+            "path": "MauiBlazorWebView.1.xaml.cs"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+    "symbols": {
+        "namespace": {
+            "type": "parameter",
+            "replaces": "MyApp.Namespace",
+            "datatype": "text",
+            "description": "namespace for the generated code"
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebView/MauiBlazorWebView.1.xaml
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/MauiBlazorWebView.1.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="MyApp.Namespace.MauiBlazorWebView__1"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:MyApp.Namespace"
+    mc:Ignorable="d">
+    <ContentPage.Content>
+        <Grid>
+            <!-- StartPath property is supported on .NET 8 Previews -->
+            <BlazorWebView HostPage="wwwroot/index.html">
+                <BlazorWebView.RootComponents>
+                    <RootComponent
+                        Selector="#app"
+                        ComponentType="{x:Type local:Main}" />
+                </BlazorWebView.RootComponents>
+            </BlazorWebView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/MauiTemplatesCLI/MauiBlazorWebView/MauiBlazorWebView.1.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/MauiBlazorWebView.1.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace MyApp.Namespace
+{
+    public partial class MauiBlazorWebView__1 : ContentPage
+    {
+        public MauiBlazorWebView__1()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/dotnetcli.host.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "namespace": {
+      "shortName": "na"
+    }
+  }
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/ide.host.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/ide.host.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "http://json.schemastore.org/vs-2017.3.host"
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/template.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json.schemastore.org/template",
+    "author": "Vijay Anand E G",
+    "defaultName": "MauiPage1",
+    "classifications": [
+        "MAUI",
+        "Android",
+        "iOS",
+        "macOS",
+        "Windows",
+        "Blazor",
+        "Code"
+    ],
+    "identity": "VijayAnand.MauiBlazorWebViewCS",
+    "groupIdentity": "VijayAnand.MauiTemplates.BlazorWebView.Code",
+    "description": "An item template for .NET MAUI ContentPage with BlazorWebView in C#",
+    "name": ".NET MAUI ContentPage with BlazorWebView (C#)",
+    "shortName": "maui-bwv-cs",
+    "sourceName": "MauiBlazorWebView.1",
+    "primaryOutputs": [
+        {
+            "path": "MauiBlazorWebView.1.cs"
+        }
+    ],
+    "tags": {
+        "language": "C#",
+        "type": "item"
+    },
+    "symbols": {
+        "namespace": {
+            "type": "parameter",
+            "replaces": "MyApp.Namespace",
+            "datatype": "text",
+            "description": "namespace for the generated code"
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/MauiBlazorWebViewCS/MauiBlazorWebView.1.cs
+++ b/src/MauiTemplatesCLI/MauiBlazorWebViewCS/MauiBlazorWebView.1.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Components.WebView.Maui;
+
+namespace MyApp.Namespace
+{
+    public partial class MauiBlazorWebView__1 : ContentPage
+    {
+        public MauiBlazorWebView__1()
+        {
+            // Below BlazorWebView initialization can be simplified in just a single line
+            // Add reference to the VijayAnand.MauiBlazor.Markup NuGet package
+            // Add this using statement VijayAnand.MauiBlazor.Markup to bring the extension methods to scope
+            // And then invoke the Configure() method on the BlazorWebView instance, example shown below
+            // new BlazorWebView().Configure("wwwroot/index.html", ("#app", typeof(Main), null));
+            var bwv = new BlazorWebView()
+            {
+                // StartPath supported on .NET 8
+                //StartPath = "/",
+                HostPage = "wwwroot/index.html"
+            };
+
+            bwv.RootComponents.Add(new RootComponent()
+            {
+                Selector = "#app",
+                ComponentType = typeof(Main),
+                Parameters = null
+            });
+
+            Content = new Grid()
+            {
+                Children =
+                {
+                    bwv
+                }
+            };
+        }
+    }
+}

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.2.0-preview.4
+3.2.0-preview.5

--- a/src/MauiTemplatesCLI/VijayAnand.MauiTemplates.csproj
+++ b/src/MauiTemplatesCLI/VijayAnand.MauiTemplates.csproj
@@ -21,7 +21,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/egvijayanand/dotnet-maui-templates</RepositoryUrl>
         <PackageTags>MAUI, Mobile, iOS, Android, WinUI3, Mac;Catalyst, macOS, VS;Code, .NET;MAUI, Desktop, Windows, WinUI, GA, Templates, Shell, Class;Library, Visual;Studio;Code, Library, Tizen, MVVM, MVU, Comet, Reactor, CLI, Hybrid, Blazor, Razor; Markup; Compiled; Bindings</PackageTags>
-        <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/release-notes.txt"))</PackageReleaseNotes>
+        <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)\release-notes.txt"))</PackageReleaseNotes>
         <PackageReadmeFile>overview.md</PackageReadmeFile>
         <PackageProjectUrl>https://egvijayanand.in/</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
@@ -29,7 +29,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <Content Include="MauiAppX\**\*;MauiClassLib\**\*;SharedClassLib\**\*;MauiPage\**\*;MauiPageCS\**\*;MauiPageRazor\**\*;MauiView\**\*;MauiViewCS\**\*;MauiViewRazor\**\*;MauiResDict\**\*;MauiShell\**\*;MauiShellCS\**\*;MauiShellRazor\**\*;MauiMvvm\**\*;MauiMvvmCS\**\*;MyClass\**\*"
+        <Content Include="MauiAppX\**\*;MauiClassLib\**\*;SharedClassLib\**\*;MauiPage\**\*;MauiPageCS\**\*;MauiPageRazor\**\*;MauiView\**\*;MauiViewCS\**\*;MauiViewRazor\**\*;MauiResDict\**\*;MauiShell\**\*;MauiShellCS\**\*;MauiShellRazor\**\*;MauiMvvm\**\*;MauiMvvmCS\**\*;MauiBlazorWebView\**\*;MauiBlazorWebViewCS\**\*;MyClass\**\*"
                  Exclude="**\bin\**;**\obj\**"/>
         <Compile Remove="**\*"/>
         <None Include="overview.md" Pack="true" PackagePath="\" />

--- a/src/MauiTemplatesCLI/overview.md
+++ b/src/MauiTemplatesCLI/overview.md
@@ -20,6 +20,8 @@ Item templates for the following:
 |ShellPage (Razor)|maui-shell-razor|
 |[ContentPage (XAML) with ViewModel](#page-with-viewmodel)|maui-mvvm|
 |[ContentPage (C#) with ViewModel](#page-with-viewmodel)|maui-mvvm-cs|
+|ContentPage with BlazorWebView (XAML)|maui-bwv|
+|ContentPage with BlazorWebView (C#)|maui-bwv-cs|
 |[Partial Class (C#)](#partial-class-item-template)|class-cs|
 
 All of these templates currently target `.NET MAUI on .NET 6/7 GA and its Service Releases and .NET 8 Previews`.
@@ -365,7 +367,7 @@ dotnet new sharedclasslib -n MyApp.UI -asp
 
 Pages:
 ```shell
-dotnet new maui-page -n LoginPage -na MyApp.Views
+dotnet new maui-page -n HomePage -na MyApp.Views
 ```
 ```shell
 dotnet new maui-page-cs -n HomePage -na MyApp.Views
@@ -385,9 +387,18 @@ dotnet new maui-mvvm -n Login
 dotnet new maui-mvvm-cs -n Login
 ```
 
+ContentPage with BlazorWebView:
+
+```shell
+dotnet new maui-bwv -n HomePage -na MyApp.Views
+```
+```shell
+dotnet new maui-bwv-cs -n HomePage -na MyApp.Views
+```
+
 Views:
 ```shell
-dotnet new maui-view -n CardView -na MyApp.Views
+dotnet new maui-view -n OrderView -na MyApp.Views
 ```
 ```shell
 dotnet new maui-view-cs -n OrderView -na MyApp.Views
@@ -485,7 +496,7 @@ dotnet new sharedclasslib --name MyApp.UI --all-supported-packages
 
 Pages:
 ```shell
-dotnet new maui-page --name LoginPage --namespace MyApp.Views
+dotnet new maui-page --name HomePage --namespace MyApp.Views
 ```
 ```shell
 dotnet new maui-page-cs --name HomePage --namespace MyApp.Views
@@ -505,9 +516,18 @@ dotnet new maui-mvvm --name Login
 dotnet new maui-mvvm-cs --name Login
 ```
 
+ContentPage with BlazorWebView:
+
+```shell
+dotnet new maui-bwv --name HomePage --namespace MyApp.Views
+```
+```shell
+dotnet new maui-bwv-cs --name HomePage --namespace MyApp.Views
+```
+
 Views:
 ```shell
-dotnet new maui-view --name CardView --namespace MyApp.Views
+dotnet new maui-view --name OrderView --namespace MyApp.Views
 ```
 ```shell
 dotnet new maui-view-cs --name OrderView --namespace MyApp.Views

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,7 +1,23 @@
 Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for articles on .NET MAUI and Blazor.
 
-What's new in ver. 3.2.0-preview.4:
+What's new in ver. 3.2.0-preview.5:
 -----------------------------------
+An item template for BlazorWebView in XAML and C#.
+
+Note: While working with .NET 7 or higher SDK, the namespace parameter in short notation needs to be passed as -p:na (i.e., it needs to be prefixed with -p:).
+
+dotnet new maui-bwv -n HomePage -na MyApp.Views
+
+dotnet new maui-bwv-cs -n HomePage -na MyApp.Views
+
+On .NET 7 or later:
+
+dotnet new maui-bwv -n HomePage -p:na MyApp.Views
+
+dotnet new maui-bwv-cs -n HomePage -p:na MyApp.Views
+
+v3.2.0-preview.4:
+
 Conditionally defined supported platforms properties based on the target platform opted-in.
 
 v3.2.0-preview.3:


### PR DESCRIPTION
* An item template for BlazorWebView in XAML and C#

_Note: While working with .NET 7 or higher SDK, the namespace parameter in short notation needs to be passed as `-p:na` (i.e., it needs to be prefixed with `-p:`)._

```shell
dotnet new maui-bwv -n HomePage -na MyApp.Views
```
```shell
dotnet new maui-bwv-cs -n HomePage -na MyApp.Views
```