### PR TITLE
Support for StartPath property on .NET 8

### DIFF
--- a/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/.template.config/template.json
@@ -35,6 +35,34 @@
             "replaces": "MyApp.Namespace",
             "datatype": "text",
             "description": "namespace for the generated code"
+        },
+        "rootNamespace": {
+            "type": "bind",
+            "binding": "msbuild:RootNamespace",
+            "replaces": "MyApp.LocalNamespace",
+            "defaultValue": "MyApp.Namespace"
+        },
+        "sdkVersion": {
+            "type": "bind",
+            "binding": "msbuild:NETCoreSdkVersion"
+        },
+        "Net7": {
+            "type": "generated",
+            "generator": "regexMatch",
+            "datatype": "bool",
+            "parameters": {
+                "pattern": "^(7\\.*\\.*-?.*)$",
+                "source": "sdkVersion"
+            }
+        },
+        "Net8": {
+            "type": "generated",
+            "generator": "regexMatch",
+            "datatype": "bool",
+            "parameters": {
+                "pattern": "^(8\\.*\\.*-?.*)$",
+                "source": "sdkVersion"
+            }
         }
     }
 }

--- a/src/MauiTemplatesCLI/MauiBlazorWebView/MauiBlazorWebView.1.xaml
+++ b/src/MauiTemplatesCLI/MauiBlazorWebView/MauiBlazorWebView.1.xaml
@@ -5,12 +5,17 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://schemas.microsoft.com/dotnet/2021/maui/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:MyApp.Namespace"
+    xmlns:local="clr-namespace:MyApp.LocalNamespace"
     mc:Ignorable="d">
     <ContentPage.Content>
         <Grid>
-            <!-- StartPath property is supported on .NET 8 Previews -->
+<!--#if (Net8)-->
+            <BlazorWebView
+                HostPage="wwwroot/index.html"
+                StartPath="/">
+<!--#else-->
             <BlazorWebView HostPage="wwwroot/index.html">
+<!--#endif-->
                 <BlazorWebView.RootComponents>
                     <RootComponent
                         Selector="#app"

--- a/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiBlazorWebViewCS/.template.config/template.json
@@ -32,6 +32,28 @@
             "replaces": "MyApp.Namespace",
             "datatype": "text",
             "description": "namespace for the generated code"
+        },
+        "sdkVersion": {
+            "type": "bind",
+            "binding": "msbuild:NETCoreSdkVersion"
+        },
+        "Net7": {
+            "type": "generated",
+            "generator": "regexMatch",
+            "datatype": "bool",
+            "parameters": {
+                "pattern": "^(7\\.*\\.*-?.*)$",
+                "source": "sdkVersion"
+            }
+        },
+        "Net8": {
+            "type": "generated",
+            "generator": "regexMatch",
+            "datatype": "bool",
+            "parameters": {
+                "pattern": "^(8\\.*\\.*-?.*)$",
+                "source": "sdkVersion"
+            }
         }
     }
 }

--- a/src/MauiTemplatesCLI/MauiBlazorWebViewCS/MauiBlazorWebView.1.cs
+++ b/src/MauiTemplatesCLI/MauiBlazorWebViewCS/MauiBlazorWebView.1.cs
@@ -13,9 +13,12 @@ namespace MyApp.Namespace
             // new BlazorWebView().Configure("wwwroot/index.html", ("#app", typeof(Main), null));
             var bwv = new BlazorWebView()
             {
-                // StartPath supported on .NET 8
-                //StartPath = "/",
+#if Net8
+                HostPage = "wwwroot/index.html",
+                StartPath = "/"
+#else
                 HostPage = "wwwroot/index.html"
+#endif
             };
 
             bwv.RootComponents.Add(new RootComponent()

--- a/src/MauiTemplatesCLI/MauiClassLib/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiClassLib/.template.config/template.json
@@ -253,6 +253,12 @@
                     "exclude": [
                         "MauiClassLib.1.sln"
                     ]
+                },
+                {
+                    "condition": "(no-solution-file)",
+                    "exclude": [
+                        "MauiClassLib.1.code-workspace"
+                    ]
                 }
             ]
         }

--- a/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
+++ b/src/MauiTemplatesCLI/MauiClassLib/MauiClassLib.1.csproj
@@ -119,12 +119,14 @@
         <!-- Minimum Target OS Version for Windows Platform -->
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     </PropertyGroup>
+    <!--#if (!no-solution-file)-->
 
     <ItemGroup>
         <None Remove="MauiClassLib.1.code-workspace" />
     </ItemGroup>
-
+    <!--#endif-->
     <!--#if (AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage)-->
+
     <ItemGroup>
     <!--#endif-->
         <!--#if (Net7OrLater)-->
@@ -148,8 +150,8 @@
     <!--#if (AddToolkitPackage || AddMarkupPackage || AddMvvmToolkitPackage)-->
     </ItemGroup>
     <!--#endif-->
-
     <!--#if (ConditionalCompilation)-->
+
     <ItemGroup Condition="'$(TargetFramework)' != 'MAUI_TFM'">
         <Compile Remove="**\*.Standard.cs" />
         <None Include="**\*.Standard.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />

--- a/src/MauiTemplatesCLI/PackageVersion.txt
+++ b/src/MauiTemplatesCLI/PackageVersion.txt
@@ -1,1 +1,1 @@
-3.2.0-preview.5
+3.2.0-preview.6

--- a/src/MauiTemplatesCLI/release-notes.txt
+++ b/src/MauiTemplatesCLI/release-notes.txt
@@ -1,7 +1,13 @@
 Join me on Developer Thoughts (https://egvijayanand.in/), an exclusive blog for articles on .NET MAUI and Blazor.
 
-What's new in ver. 3.2.0-preview.5:
+What's new in ver. 3.2.0-preview.6:
 -----------------------------------
+With support for StartPath property while creating the BlazorWebView item templates on .NET 8.
+
+Note: Restore the project before making use of the item template.
+
+v3.2.0-preview.5:
+
 An item template for BlazorWebView in XAML and C#.
 
 Note: While working with .NET 7 or higher SDK, the namespace parameter in short notation needs to be passed as -p:na (i.e., it needs to be prefixed with -p:).


### PR DESCRIPTION
* With support for the `StartPath` property while creating the BlazorWebView item templates on .NET 8