### PR TITLE
Scope Resolution

### DIFF
--- a/src/MauiTemplatesCLI/MauiItem/.template.config/template.json
+++ b/src/MauiTemplatesCLI/MauiItem/.template.config/template.json
@@ -56,6 +56,18 @@
             "default": "false",
             "description": "If true, the output is generated without a C# code-behind file."
         },
+        "TypeRename": {
+            "type": "derived",
+            "valueSource": "base",
+            "valueTransform": "ValueWithoutScope",
+            "replaces": "ContentView"
+        },
+        "ContextRename": {
+            "type": "derived",
+            "valueSource": "generic",
+            "valueTransform": "ValueWithoutScope",
+            "replaces": "TContext"
+        },
         "IsGeneric": {
             "type": "computed",
             "value": "(generic != \"\")"
@@ -63,6 +75,13 @@
         "XamlOnly": {
             "type": "computed",
             "value": "(xaml-only)"
+        }
+    },
+    "forms": {
+        "ValueWithoutScope": {
+            "identifier": "replace",
+            "pattern": "^.*\\:(?=[^\\:]+$)",
+            "replacement": ""
         }
     },
     "sources": [

--- a/src/MauiTemplatesCLI/MauiItem/MauiItem.1.xaml.cs
+++ b/src/MauiTemplatesCLI/MauiItem/MauiItem.1.xaml.cs
@@ -1,9 +1,9 @@
 ﻿namespace MyApp.Namespace
 {
 #if IsGeneric
-    public partial class MauiItem__1 : ContentPage<TObject>
+    public partial class MauiItem__1 : ContentView<TContext>
 #else
-    public partial class MauiItem__1 : ContentPage
+    public partial class MauiItem__1 : ContentView
 #endif
     {
         public MauiItem__1()


### PR DESCRIPTION
* Ability to pass the `xmlns` value from the CLI so that it appropriately replaces the value in XAML and C#

_Note: Defining the value of that `xmlns` is still up to the user as it is outside the scope of this feature._

**Sample 1:**

```shell
dotnet new maui-item -n ThemePopup -b mct:Popup
```
**Output:** `ThemePopup.xaml` and `ThemePopup.xaml.cs`
```cs
public partial class ThemePopup : Popup {}
```

**Sample 2:**

```shell
dotnet new maui-item -n CartPage -b vw:MauiPage -g vm:CartViewModel
```
**Output:** `CartPage.xaml` and `CartPage.xaml.cs`
```cs
public partial class CartPage : MauiPage<CartViewModel> {}
```
